### PR TITLE
9 testvalidate password recovery flow using resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Secret key for JWT
 SECRET_KEY=
 
+# Base URL
+BASE_URL=http://localhost:8000
+
 # Database
 DB_USER=
 DB_PASSWORD=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           echo "DB_PORT=5432" >> $GITHUB_ENV
           echo "DB_NAME=test_db" >> $GITHUB_ENV
           echo "SECRET_KEY=$(openssl rand -base64 32)" >> $GITHUB_ENV
+          echo "BASE_URL=http://localhost:8000" >> $GITHUB_ENV
         
       - name: Verify environment variables
         run: |

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -258,6 +258,21 @@ class NeedsNewTokens(Exception):
         self.refresh_token = refresh_token
 
 
+def generate_password_reset_url(email: str, token: str) -> str:
+    """
+    Generates the password reset URL with proper query parameters.
+
+    Args:
+        email: User's email address
+        token: Password reset token
+
+    Returns:
+        Complete password reset URL
+    """
+    base_url = os.getenv('BASE_URL')
+    return f"{base_url}/auth/reset_password?email={email}&token={token}"
+
+
 def send_reset_email(email: str, session: Session):
     # Check for an existing unexpired token
     user = session.exec(select(User).where(User.email == email)).first()
@@ -281,12 +296,12 @@ def send_reset_email(email: str, session: Session):
         session.add(reset_token)
 
         try:
-            # TODO: Use a templating engine
+            reset_url = generate_password_reset_url(email, token)
             params: resend.Emails.SendParams = {
                 "from": "noreply@promptlytechnologies.com",
                 "to": [email],
                 "subject": "Password Reset Request",
-                "html": f"<p>Click <a href='{os.getenv('BASE_URL')}/auth/reset_password?email={email}&token={token}'>here</a> to reset your password.</p>",
+                "html": f"<p>Click <a href='{reset_url}'>here</a> to reset your password.</p>",
             }
 
             sent_email: resend.Email = resend.Emails.send(params)

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -286,7 +286,7 @@ def send_reset_email(email: str, session: Session):
                 "from": "noreply@promptlytechnologies.com",
                 "to": [email],
                 "subject": "Password Reset Request",
-                "html": f"<p>Click <a href='{os.getenv('BASE_URL')}/reset_password?email={email}&token={token}'>here</a> to reset your password.</p>",
+                "html": f"<p>Click <a href='{os.getenv('BASE_URL')}/auth/reset_password?email={email}&token={token}'>here</a> to reset your password.</p>",
             }
 
             sent_email: resend.Email = resend.Emails.send(params)


### PR DESCRIPTION
- Uncommented the test of the password reset endpoint and mocked the call to resend.send
- Fixed a bug in the password reset flow and verified that the flow is working in the application
- Added missing BASE_URL environment variable in the .env.example file
- Added a helper function to generate the password reset link to include in the email, and added a test to validate this URL against the actual endpoint