### PR TITLE
Email address update confirmation flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -259,7 +259,8 @@ async def read_dashboard(
 @app.get("/profile")
 async def read_profile(
     params: dict = Depends(common_authenticated_parameters),
-    email_update_requested: Optional[str] = "false"
+    email_update_requested: Optional[str] = "false",
+    email_updated: Optional[str] = "false"
 ):
     # Add image constraints to the template context
     params.update({
@@ -267,7 +268,8 @@ async def read_profile(
         "min_dimension": MIN_DIMENSION,
         "max_dimension": MAX_DIMENSION,
         "allowed_formats": list(ALLOWED_CONTENT_TYPES.keys()),
-        "email_update_requested": email_update_requested
+        "email_update_requested": email_update_requested,
+        "email_updated": email_updated
     })
     return templates.TemplateResponse(params["request"], "users/profile.html", params)
 

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ async def lifespan(app: FastAPI):
     # Optional shutdown logic
 
 
-app = FastAPI(lifespan=lifespan)
+app: FastAPI = FastAPI(lifespan=lifespan)
 
 # Mount static files (e.g., CSS, JS)
 app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/main.py
+++ b/main.py
@@ -169,10 +169,12 @@ async def read_home(
 
 @app.get("/login")
 async def read_login(
-    params: dict = Depends(common_unauthenticated_parameters)
+    params: dict = Depends(common_unauthenticated_parameters),
+    email_updated: Optional[str] = "false"
 ):
     if params["user"]:
         return RedirectResponse(url="/dashboard", status_code=302)
+    params["email_updated"] = email_updated
     return templates.TemplateResponse(params["request"], "authentication/login.html", params)
 
 
@@ -256,14 +258,16 @@ async def read_dashboard(
 
 @app.get("/profile")
 async def read_profile(
-    params: dict = Depends(common_authenticated_parameters)
+    params: dict = Depends(common_authenticated_parameters),
+    email_update_requested: Optional[str] = "false"
 ):
     # Add image constraints to the template context
     params.update({
         "max_file_size_mb": MAX_FILE_SIZE / (1024 * 1024),  # Convert bytes to MB
         "min_dimension": MIN_DIMENSION,
         "max_dimension": MAX_DIMENSION,
-        "allowed_formats": list(ALLOWED_CONTENT_TYPES.keys())
+        "allowed_formats": list(ALLOWED_CONTENT_TYPES.keys()),
+        "email_update_requested": email_update_requested
     })
     return templates.TemplateResponse(params["request"], "users/profile.html", params)
 

--- a/routers/authentication.py
+++ b/routers/authentication.py
@@ -338,7 +338,7 @@ async def request_email_update(
     )
 
     return RedirectResponse(
-        url="/settings?email_update_requested=true",
+        url="/profile?email_update_requested=true",
         status_code=303
     )
 
@@ -370,6 +370,6 @@ async def confirm_email_update(
     session.commit()
 
     return RedirectResponse(
-        url="/settings?email_updated=true",
+        url="/login?email_updated=true",
         status_code=303
     )

--- a/routers/authentication.py
+++ b/routers/authentication.py
@@ -195,9 +195,20 @@ async def register(
     refresh_token = create_refresh_token(data={"sub": db_user.email})
     # Set cookie
     response = RedirectResponse(url="/", status_code=303)
-    response.set_cookie(key="access_token", value=access_token, httponly=True)
-    response.set_cookie(key="refresh_token",
-                        value=refresh_token, httponly=True)
+    response.set_cookie(
+        key="access_token",
+        value=access_token,
+        httponly=True,
+        secure=True,
+        samesite="strict"
+    )
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token,
+        httponly=True,
+        secure=True,
+        samesite="strict"
+    )
 
     return response
 
@@ -390,25 +401,28 @@ async def confirm_email_update(
     session.commit()
 
     # Create new tokens with the updated email
-    access_token = create_access_token(data={"sub": new_email})
+    access_token = create_access_token(data={"sub": new_email, "fresh": True})
     refresh_token = create_refresh_token(data={"sub": new_email})
 
+    # Set cookies before redirecting
     response = RedirectResponse(
         url="/profile?email_updated=true",
         status_code=303
     )
+
+    # Add secure cookie attributes
     response.set_cookie(
         key="access_token",
         value=access_token,
         httponly=True,
         secure=True,
-        samesite="strict"
+        samesite="lax"
     )
     response.set_cookie(
         key="refresh_token",
         value=refresh_token,
         httponly=True,
         secure=True,
-        samesite="strict"
+        samesite="lax"
     )
     return response

--- a/routers/organization.py
+++ b/routers/organization.py
@@ -10,6 +10,8 @@ from datetime import datetime
 
 logger = getLogger("uvicorn.error")
 
+router = APIRouter(prefix="/organizations", tags=["organizations"])
+
 # --- Custom Exceptions ---
 
 
@@ -35,9 +37,6 @@ class OrganizationNameTakenError(HTTPException):
             status_code=400,
             detail="Organization name already taken"
         )
-
-
-router = APIRouter(prefix="/organizations", tags=["organizations"])
 
 
 # --- Server Request and Response Models ---

--- a/routers/user.py
+++ b/routers/user.py
@@ -16,7 +16,6 @@ router = APIRouter(prefix="/user", tags=["user"])
 class UpdateProfile(BaseModel):
     """Request model for updating user profile information"""
     name: str
-    email: EmailStr
     avatar_file: Optional[bytes] = None
     avatar_content_type: Optional[str] = None
 
@@ -24,7 +23,6 @@ class UpdateProfile(BaseModel):
     async def as_form(
         cls,
         name: str = Form(...),
-        email: EmailStr = Form(...),
         avatar_file: Optional[UploadFile] = File(None),
     ):
         avatar_data = None
@@ -36,7 +34,6 @@ class UpdateProfile(BaseModel):
 
         return cls(
             name=name,
-            email=email,
             avatar_file=avatar_data,
             avatar_content_type=avatar_content_type
         )
@@ -73,7 +70,6 @@ async def update_profile(
 
     # Update user details
     user.name = user_profile.name
-    user.email = user_profile.email
     
     if user_profile.avatar_file:
         user.avatar_data = user_profile.avatar_file

--- a/templates/authentication/login.html
+++ b/templates/authentication/login.html
@@ -6,6 +6,13 @@
 
 {% block auth_content %}
 <div class="login-form">
+
+    {% if email_updated == "true" %}
+    <div class="alert alert-success" role="alert">
+        Your email address has been successfully updated. Please login with your new email address.
+    </div>
+    {% endif %}
+
     <form method="POST" action="{{ url_for('login') }}" class="needs-validation" novalidate>
         <!-- Email Input -->
         <div class="mb-3">

--- a/templates/authentication/login.html
+++ b/templates/authentication/login.html
@@ -6,13 +6,6 @@
 
 {% block auth_content %}
 <div class="login-form">
-
-    {% if email_updated == "true" %}
-    <div class="alert alert-success" role="alert">
-        Your email address has been successfully updated. Please login with your new email address.
-    </div>
-    {% endif %}
-
     <form method="POST" action="{{ url_for('login') }}" class="needs-validation" novalidate>
         <!-- Email Input -->
         <div class="mb-3">

--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -24,7 +24,11 @@
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <button class="profile-button btn p-0 border-0 bg-transparent">
-                            {{ render_silhouette() }}
+                            {% if user.avatar_data %}
+                                <img src="{{ url_for('get_avatar') }}" alt="User Avatar" class="d-inline-block align-top" width="30" height="30" style="border-radius: 50%;">
+                            {% else %}
+                                {{ render_silhouette() }}
+                            {% endif %}
                         </button>
                     </a>
                     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">

--- a/templates/emails/update_email_email.html
+++ b/templates/emails/update_email_email.html
@@ -1,0 +1,12 @@
+{% extends "emails/base_email.html" %}
+
+{% block email_title %}Email Update Request{% endblock %}
+
+{% block email_content %}
+    <h1>Confirm Your New Email Address</h1>
+    <p>You have requested to change your email address from {{ current_email }} to {{ new_email }}.</p>
+    <p>Click the link below to confirm this change:</p>
+    <p><a href="{{ confirmation_url }}">Confirm Email Update</a></p>
+    <p>If you did not request this change, please ignore this email.</p>
+    <p>This link will expire in 1 hour.</p>
+{% endblock %}

--- a/templates/users/organization.html
+++ b/templates/users/organization.html
@@ -63,7 +63,11 @@
                             {% for user in role.users %}
                             <tr>
                                 <td class="text-center" style="width: 50px;">
-                                    {{ render_silhouette(width=40, height=40) }}
+                                    {% if user.avatar_data %}
+                                        <img src="{{ url_for('get_avatar') }}" alt="User Avatar" class="d-inline-block align-top" width="40" height="40" style="border-radius: 50%;">
+                                    {% else %}
+                                        {{ render_silhouette(width=40, height=40) }}
+                                    {% endif %}
                                 </td>
                                 <td>{{ user.name }}</td>
                                 <td>{{ user.email }}</td>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -41,10 +41,6 @@
                     <input type="text" class="form-control" id="name" name="name" value="{{ user.name }}">
                 </div>
                 <div class="mb-3">
-                    <label for="email" class="form-label">Email</label>
-                    <input type="email" class="form-control" id="email" name="email" value="{{ user.email }}">
-                </div>
-                <div class="mb-3">
                     <label for="avatar_file" class="form-label">Avatar</label>
                     <input type="file" class="form-control" id="avatar_file" name="avatar_file" accept="image/*">
                     <div class="form-text">
@@ -62,13 +58,29 @@
         </div>
     </div>
 
+    <!-- New Email Update Section -->
+    <div class="card mb-4">
+        <div class="card-header">
+            Update Email
+        </div>
+        <div class="card-body">
+            <form action="{{ url_for('request_email_update') }}" method="post">
+                <div class="mb-3">
+                    <label for="new_email" class="form-label">New Email Address</label>
+                    <input type="email" class="form-control" id="new_email" name="new_email" value="{{ user.email }}">
+                </div>
+                <p class="form-text">A confirmation link will be sent to your new email address to verify the change.</p>
+                <button type="submit" class="btn btn-primary">Update Email</button>
+            </form>
+        </div>
+    </div>
+
     <!-- Change Password -->
     <div class="card mb-4">
         <div class="card-header">
             Change Password
         </div>
         <div class="card-body">
-            <!-- TODO: Trigger password reset via email confirmation -->
             <form action="{{ url_for('forgot_password') }}" method="post">
                 <input type="hidden" name="email" value="{{ user.email }}">
                 <p>To change your password, please confirm your email. A password reset link will be sent to your email address.</p>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -8,6 +8,12 @@
 <div class="container mt-5">
     <h1 class="mb-4">User Profile</h1>
     
+    {% if email_update_requested == "true" %}
+    <div class="alert alert-info" role="alert">
+        Please check your current email address for a confirmation link to complete the email update.
+    </div>
+    {% endif %}
+
     <!-- Basic Information -->
     <div class="card mb-4" id="basic-info">
         <div class="card-header">
@@ -102,7 +108,7 @@
                 <p class="text-danger">This action cannot be undone. Please confirm your password to delete your account.</p>
                 <div class="mb-3">
                     <label for="confirm_delete_password" class="form-label">Password</label>
-                    <input type="password" class="form-control" id="confirm_delete_password" name="confirm_delete_password">
+                    <input type="password" class="form-control" id="confirm_delete_password" name="confirm_delete_password" autocomplete="off">
                 </div>
                 <button type="submit" class="btn btn-danger">Delete Account</button>
             </form>

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -14,6 +14,12 @@
     </div>
     {% endif %}
 
+    {% if email_updated == "true" %}
+    <div class="alert alert-success" role="alert">
+        Your email address has been successfully updated.
+    </div>
+    {% endif %}
+
     <!-- Basic Information -->
     <div class="card mb-4" id="basic-info">
         <div class="card-header">

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -215,9 +215,9 @@ def test_send_email_update_confirmation(mock_send: MagicMock) -> None:
     # Test existing token case
     session.reset_mock()
     session.exec.return_value.first.return_value = EmailUpdateToken()  # Existing token
-    
+
     send_email_update_confirmation(current_email, new_email, user_id, session)
-    
+
     # Verify no new token was created or email sent
     assert not session.add.called
     assert not session.commit.called
@@ -228,7 +228,7 @@ def test_get_user_from_email_update_token() -> None:
     Tests retrieving a user using an email update token.
     """
     session = MagicMock()
-    
+
     # Test valid token
     mock_user = User(id=1, email="test@example.com")
     mock_token = EmailUpdateToken(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,7 +17,7 @@ from utils.auth import (
 )
 
 
-def test_convert_python_regex_to_html():
+def test_convert_python_regex_to_html() -> None:
     PYTHON_SPECIAL_CHARS = r"(?=.*[\[\]\\@$!%*?&{}<>.,'#\-_=+\(\):;|~/\^])"
     HTML_EQUIVALENT = r"(?=.*[\[\]\\@$!%*?&\{\}\<\>\.\,\\'#\-_=\+\(\):;\|~\/\^])"
 
@@ -26,14 +26,14 @@ def test_convert_python_regex_to_html():
     assert PYTHON_SPECIAL_CHARS == HTML_EQUIVALENT
 
 
-def test_password_hashing():
+def test_password_hashing() -> None:
     password = "Test123!@#"
     hashed = get_password_hash(password)
     assert verify_password(password, hashed)
     assert not verify_password("wrong_password", hashed)
 
 
-def test_token_creation_and_validation():
+def test_token_creation_and_validation() -> None:
     data = {"sub": "test@example.com"}
 
     # Test access token
@@ -51,7 +51,7 @@ def test_token_creation_and_validation():
     assert decoded["type"] == "refresh"
 
 
-def test_expired_token():
+def test_expired_token() -> None:
     data = {"sub": "test@example.com"}
     expired_delta = timedelta(minutes=-10)
     expired_token = create_access_token(data, expired_delta)
@@ -59,13 +59,13 @@ def test_expired_token():
     assert decoded is None
 
 
-def test_invalid_token_type():
+def test_invalid_token_type() -> None:
     data = {"sub": "test@example.com"}
     access_token = create_access_token(data)
     decoded = validate_token(access_token, "refresh")
     assert decoded is None
 
-def test_password_reset_url_generation():
+def test_password_reset_url_generation() -> None:
     """
     Tests that the password reset URL is correctly formatted and contains
     the required query parameters.
@@ -91,7 +91,7 @@ def test_password_reset_url_generation():
     assert query_params["email"][0] == test_email
     assert query_params["token"][0] == test_token
 
-def test_password_pattern():
+def test_password_pattern() -> None:
     """
     Tests that the password pattern is correctly defined. to require at least
     one uppercase letter, one lowercase letter, one digit, and one special

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -9,11 +9,12 @@ from urllib.parse import urlparse, parse_qs
 from html import unescape
 
 from main import app
-from utils.models import User, PasswordResetToken
+from utils.models import User, PasswordResetToken, UserPassword, EmailUpdateToken
 from utils.auth import (
     create_access_token,
     verify_password,
     validate_token,
+    get_password_hash
 )
 from .conftest import SetupError
 
@@ -199,7 +200,7 @@ def test_register_with_existing_email(unauth_client: TestClient, test_user: User
             "confirm_password": "Test123!@#"
         }
     )
-    assert response.status_code == 400
+    assert response.status_code == 409
 
 
 def test_login_with_invalid_credentials(unauth_client: TestClient, test_user: User):
@@ -210,7 +211,7 @@ def test_login_with_invalid_credentials(unauth_client: TestClient, test_user: Us
             "password": "WrongPass123!@#"
         }
     )
-    assert response.status_code == 400
+    assert response.status_code == 401
 
 
 def test_password_reset_with_invalid_token(unauth_client: TestClient, test_user: User):
@@ -223,7 +224,7 @@ def test_password_reset_with_invalid_token(unauth_client: TestClient, test_user:
             "confirm_new_password": "NewPass123!@#"
         }
     )
-    assert response.status_code == 400
+    assert response.status_code == 401
 
 
 def test_password_reset_email_url(unauth_client: TestClient, session: Session, test_user: User, mock_resend_send):
@@ -264,3 +265,144 @@ def test_password_reset_email_url(unauth_client: TestClient, session: Session, t
     assert parsed.path == str(reset_password_path)
     assert query_params["email"][0] == test_user.email
     assert query_params["token"][0] == reset_token.token
+
+
+def test_request_email_update_success(auth_client: TestClient, test_user: User, mock_resend_send):
+    """Test successful email update request"""
+    new_email = "newemail@example.com"
+    
+    response = auth_client.post(
+        app.url_path_for("request_email_update"),
+        data={"new_email": new_email},
+        follow_redirects=False
+    )
+    
+    assert response.status_code == 303
+    assert "profile?email_update_requested=true" in response.headers["location"]
+    
+    # Verify email was "sent"
+    mock_resend_send.assert_called_once()
+    call_args = mock_resend_send.call_args[0][0]
+    
+    # Verify email content
+    assert call_args["to"] == [test_user.email]
+    assert call_args["from"] == "noreply@promptlytechnologies.com"
+    assert "Confirm Email Update" in call_args["subject"]
+    assert "confirm_email_update" in call_args["html"]
+    assert new_email in call_args["html"]
+
+
+def test_request_email_update_already_registered(auth_client: TestClient, session: Session, test_user: User):
+    """Test email update request with already registered email"""
+    # Create another user with the target email
+    existing_email = "existing@example.com"
+    existing_user = User(
+        name="Existing User",
+        email=existing_email,
+        password=UserPassword(hashed_password=get_password_hash("Test123!@#"))
+    )
+    session.add(existing_user)
+    session.commit()
+    
+    response = auth_client.post(
+        app.url_path_for("request_email_update"),
+        data={"new_email": existing_email}
+    )
+    
+    assert response.status_code == 409
+    assert "already registered" in response.text
+
+
+def test_request_email_update_unauthenticated(unauth_client: TestClient):
+    """Test email update request without authentication"""
+    response = unauth_client.post(
+        app.url_path_for("request_email_update"),
+        data={"new_email": "new@example.com"},
+        follow_redirects=False
+    )
+    
+    assert response.status_code == 303  # Redirect to login
+
+
+def test_confirm_email_update_success(unauth_client: TestClient, session: Session, test_user: User):
+    """Test successful email update confirmation"""
+    new_email = "updated@example.com"
+    
+    # Create an email update token
+    update_token = EmailUpdateToken(user_id=test_user.id)
+    session.add(update_token)
+    session.commit()
+    
+    response = unauth_client.get(
+        app.url_path_for("confirm_email_update"),
+        params={
+            "user_id": test_user.id,
+            "token": update_token.token,
+            "new_email": new_email
+        },
+        follow_redirects=False
+    )
+    
+    assert response.status_code == 303
+    assert "profile?email_updated=true" in response.headers["location"]
+    
+    # Verify email was updated
+    session.refresh(test_user)
+    assert test_user.email == new_email
+    
+    # Verify token was marked as used
+    session.refresh(update_token)
+    assert update_token.used
+    
+    # Verify new auth cookies were set
+    cookies = response.cookies
+    assert "access_token" in cookies
+    assert "refresh_token" in cookies
+
+
+def test_confirm_email_update_invalid_token(unauth_client: TestClient, session: Session, test_user: User):
+    """Test email update confirmation with invalid token"""
+    response = unauth_client.get(
+        app.url_path_for("confirm_email_update"),
+        params={
+            "user_id": test_user.id,
+            "token": "invalid_token",
+            "new_email": "new@example.com"
+        }
+    )
+    
+    assert response.status_code == 401
+    assert "Invalid or expired" in response.text
+    
+    # Verify email was not updated
+    session.refresh(test_user)
+    assert test_user.email == "test@example.com"
+
+
+def test_confirm_email_update_used_token(unauth_client: TestClient, session: Session, test_user: User):
+    """Test email update confirmation with already used token"""
+    # Create an already used token
+    used_token = PasswordResetToken(
+        user_id=test_user.id,
+        token="test_used_token",
+        used=True,
+        token_type="email_update"
+    )
+    session.add(used_token)
+    session.commit()
+    
+    response = unauth_client.get(
+        app.url_path_for("confirm_email_update"),
+        params={
+            "user_id": test_user.id,
+            "token": used_token.token,
+            "new_email": "new@example.com"
+        }
+    )
+    
+    assert response.status_code == 401
+    assert "Invalid or expired" in response.text
+    
+    # Verify email was not updated
+    session.refresh(test_user)
+    assert test_user.email == "test@example.com"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -17,8 +17,7 @@ def test_update_profile_unauthorized(unauth_client: TestClient):
     response: Response = unauth_client.post(
         app.url_path_for("update_profile"),
         data={
-            "name": "New Name",
-            "email": "new@example.com",
+            "name": "New Name"
         },
         files={
             "avatar_file": ("test_avatar.jpg", b"fake image data", "image/jpeg")
@@ -40,8 +39,7 @@ def test_update_profile_authorized(mock_validate, auth_client: TestClient, test_
     response: Response = auth_client.post(
         app.url_path_for("update_profile"),
         data={
-            "name": "Updated Name",
-            "email": "updated@example.com",
+            "name": "Updated Name"
         },
         files={
             "avatar_file": ("test_avatar.jpg", b"fake image data", "image/jpeg")
@@ -54,7 +52,6 @@ def test_update_profile_authorized(mock_validate, auth_client: TestClient, test_
     # Verify changes in database
     session.refresh(test_user)
     assert test_user.name == "Updated Name"
-    assert test_user.email == "updated@example.com"
     assert test_user.avatar_data == MOCK_IMAGE_DATA
     assert test_user.avatar_content_type == MOCK_CONTENT_TYPE
 
@@ -67,8 +64,7 @@ def test_update_profile_without_avatar(auth_client: TestClient, test_user: User,
     response: Response = auth_client.post(
         app.url_path_for("update_profile"),
         data={
-            "name": "Updated Name",
-            "email": "updated@example.com",
+            "name": "Updated Name"
         },
         follow_redirects=False
     )
@@ -78,7 +74,6 @@ def test_update_profile_without_avatar(auth_client: TestClient, test_user: User,
     # Verify changes in database
     session.refresh(test_user)
     assert test_user.name == "Updated Name"
-    assert test_user.email == "updated@example.com"
 
 
 def test_delete_account_unauthorized(unauth_client: TestClient):
@@ -130,8 +125,7 @@ def test_get_avatar_authorized(mock_validate, auth_client: TestClient, test_user
     auth_client.post(
         app.url_path_for("update_profile"),
         data={
-            "name": test_user.name,
-            "email": test_user.email,
+            "name": test_user.name
         },
         files={
             "avatar_file": ("test_avatar.jpg", b"fake image data", "image/jpeg")
@@ -167,8 +161,7 @@ def test_update_profile_invalid_image(mock_validate, auth_client: TestClient):
     response: Response = auth_client.post(
         app.url_path_for("update_profile"),
         data={
-            "name": "Updated Name",
-            "email": "updated@example.com",
+            "name": "Updated Name"
         },
         files={
             "avatar_file": ("test_avatar.jpg", b"invalid image data", "image/jpeg")

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -16,7 +16,7 @@ from jinja2.environment import Template
 from fastapi.templating import Jinja2Templates
 from fastapi import Depends, Cookie, HTTPException, status
 from utils.db import get_session
-from utils.models import User, Role, PasswordResetToken
+from utils.models import User, Role, PasswordResetToken, EmailUpdateToken
 
 load_dotenv()
 resend.api_key = os.environ["RESEND_API_KEY"]
@@ -434,3 +434,86 @@ def get_user_with_relations(
     ).one()
 
     return eager_user
+
+
+def generate_email_update_url(user_id: int, token: str, new_email: str) -> str:
+    """
+    Generates the email update confirmation URL with proper query parameters.
+    """
+    base_url = os.getenv('BASE_URL')
+    return f"{base_url}/auth/confirm_email_update?user_id={user_id}&token={token}&new_email={new_email}"
+
+
+def send_email_update_confirmation(
+    current_email: str,
+    new_email: str,
+    user_id: int,
+    session: Session
+) -> None:
+    # Check for an existing unexpired token
+    existing_token = session.exec(
+        select(EmailUpdateToken)
+        .where(
+            EmailUpdateToken.user_id == user_id,
+            EmailUpdateToken.expires_at > datetime.now(UTC),
+            EmailUpdateToken.used == False
+        )
+    ).first()
+
+    if existing_token:
+        logger.debug("An unexpired email update token already exists for this user.")
+        return
+
+    # Generate a new token
+    token = EmailUpdateToken(user_id=user_id)
+    session.add(token)
+
+    try:
+        confirmation_url = generate_email_update_url(
+            user_id, token.token, new_email)
+
+        # Render the email template
+        template = templates.get_template("emails/update_email.html")
+        html_content = template.render({
+            "confirmation_url": confirmation_url,
+            "current_email": current_email,
+            "new_email": new_email
+        })
+
+        params: resend.Emails.SendParams = {
+            "from": "noreply@promptlytechnologies.com",
+            "to": [current_email],
+            "subject": "Confirm Email Update",
+            "html": html_content,
+        }
+
+        sent_email: resend.Email = resend.Emails.send(params)
+        logger.debug(f"Email update confirmation sent: {sent_email.get('id')}")
+
+        session.commit()
+    except Exception as e:
+        logger.error(f"Failed to send email update confirmation: {e}")
+        session.rollback()
+
+
+def get_user_from_email_update_token(
+    user_id: int,
+    token: str,
+    session: Session
+) -> tuple[Optional[User], Optional[EmailUpdateToken]]:
+    result = session.exec(
+        select(User, EmailUpdateToken)
+        .where(
+            User.id == user_id,
+            EmailUpdateToken.token == token,
+            EmailUpdateToken.expires_at > datetime.now(UTC),
+            EmailUpdateToken.used == False,
+            EmailUpdateToken.user_id == User.id
+        )
+    ).first()
+
+    if not result:
+        return None, None
+
+    user, update_token = result
+    return user, update_token

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -473,7 +473,7 @@ def send_email_update_confirmation(
             user_id, token.token, new_email)
 
         # Render the email template
-        template = templates.get_template("emails/update_email.html")
+        template = templates.get_template("emails/update_email_email.html")
         html_content = template.render({
             "confirmation_url": confirmation_url,
             "current_email": current_email,

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -87,6 +87,13 @@ HTML_PASSWORD_PATTERN = "".join(
 # --- Custom Exceptions ---
 
 
+class NeedsNewTokens(Exception):
+    def __init__(self, user: User, access_token: str, refresh_token: str):
+        self.user = user
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+
+
 class AuthenticationError(HTTPException):
     def __init__(self):
         super().__init__(
@@ -322,13 +329,6 @@ def get_optional_user(
         return user
 
     return None
-
-
-class NeedsNewTokens(Exception):
-    def __init__(self, user: User, access_token: str, refresh_token: str):
-        self.user = user
-        self.access_token = access_token
-        self.refresh_token = refresh_token
 
 
 def generate_password_reset_url(email: str, token: str) -> str:

--- a/utils/models.py
+++ b/utils/models.py
@@ -215,6 +215,12 @@ class User(SQLModel, table=True):
             "cascade": "all, delete-orphan"
         }
     )
+    email_update_tokens: Mapped[List["EmailUpdateToken"]] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={
+            "cascade": "all, delete-orphan"
+        }
+    )
     password: Mapped[Optional[UserPassword]] = Relationship(
         back_populates="user"
     )

--- a/utils/models.py
+++ b/utils/models.py
@@ -161,6 +161,25 @@ class PasswordResetToken(SQLModel, table=True):
         return datetime.now(UTC) > self.expires_at.replace(tzinfo=UTC)
 
 
+class EmailUpdateToken(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: Optional[int] = Field(foreign_key="user.id")
+    token: str = Field(default_factory=lambda: str(
+        uuid4()), index=True, unique=True)
+    expires_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC) + timedelta(hours=1))
+    used: bool = Field(default=False)
+
+    user: Mapped[Optional["User"]] = Relationship(
+        back_populates="email_update_tokens")
+
+    def is_expired(self) -> bool:
+        """
+        Check if the token has expired
+        """
+        return datetime.now(UTC) > self.expires_at.replace(tzinfo=UTC)
+
+
 class UserPassword(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     user_id: Optional[int] = Field(foreign_key="user.id", unique=True)


### PR DESCRIPTION
- [x] Implement POST endpoint to request email update and GET endpoint to confirm it, with corresponding token model and helpers to handle templating and sending the email
- [x] Update profile.html and corresponding routes to factor out the email update as a separate section
- [x] Build unit tests to make sure this all works correctly
- [x] Maybe log the user back in automatically rather than make them do it manually?

Closes #14 