### PR TITLE
issue/135 fix sql bool in auth

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,6 @@ def env_vars(monkeypatch):
         m.setenv("DB_NAME", "qual2db4-test-db")
         m.setenv("RESEND_API_KEY", "test")
         m.setenv("EMAIL_FROM", "test@example.com")
-        m.setenv("QUALTRICS_BASE_URL", "test")
-        m.setenv("QUALTRICS_API_TOKEN", "test")
         m.setenv("BASE_URL", "http://localhost:8000")
         yield
 

--- a/utils/core/auth.py
+++ b/utils/core/auth.py
@@ -177,7 +177,7 @@ def send_reset_email(email: str, session: Session) -> None:
             .where(
                 PasswordResetToken.account_id == account.id,
                 PasswordResetToken.expires_at > datetime.now(UTC),
-                not PasswordResetToken.used
+                PasswordResetToken.used == False  # noqa: E712 - SQL expression for boolean false
             )
         ).first()
 
@@ -238,7 +238,7 @@ def send_email_update_confirmation(
         .where(
             EmailUpdateToken.account_id == account_id,
             EmailUpdateToken.expires_at > datetime.now(UTC),
-            not EmailUpdateToken.used
+            EmailUpdateToken.used == False  # noqa: E712 - SQL expression for boolean false
         )
     ).first()
 


### PR DESCRIPTION
- **Removed erroneously included env vars**
- **auth: use SQL comparison for boolean false in queries (Fixes #135) [no ci]**
