### PR TITLE
fix: enable password manager autofill for both password fields

### DIFF
--- a/templates/account/register.html
+++ b/templates/account/register.html
@@ -43,9 +43,8 @@
         <!-- Confirm Password Input -->
         <div class="mb-3">
             <label for="confirm_password" class="form-label">Confirm Password</label>
-            <input type="password" class="form-control" id="confirm_password" name="confirm_password" 
-                   placeholder="Confirm your password" required
-                   autocomplete="new-password">
+            <input type="password" class="form-control" id="confirm_password" name="confirm_password"
+                   placeholder="Confirm your password" required>
             <div class="invalid-feedback">
                 Passwords do not match.
             </div>


### PR DESCRIPTION
## Summary
- Removed `autocomplete="new-password"` from the password confirmation field in the registration form
- Password managers now autofill both password fields when filling credentials
- Aligns behavior with industry standard practice on major websites

## Technical Details
The primary password field retains `autocomplete="new-password"` to indicate where password managers should save/generate passwords. The confirmation field now has no autocomplete attribute, allowing password managers to infer it should match the primary password field.

## Test plan
- [ ] Test with Chrome's password manager: generate a new password and verify both fields are filled
- [ ] Test with Firefox's password manager: generate a new password and verify both fields are filled
- [ ] Test with 1Password/LastPass: verify autofill works for both fields
- [ ] Verify password validation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)