### PR TITLE
docs: remove references to deleted llms.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,10 @@ uv run mypy .
 ## Developing with LLMs
 
 The `.cursor/rules` folder contains a set of AI rules for working on
-this codebase in the Cursor IDE. We have also provided an
-[llms.txt](static/llms.txt) system prompt file for use with other
-agentic LLM workflows and exposed the full Markdown-formatted project
-documentation as a [single text file](docs/static/documentation.txt) for
-easy downloading and embedding for RAG.
+this codebase in the Cursor IDE. We have also exposed the full
+Markdown-formatted project documentation as a [single text
+file](docs/static/documentation.txt) for easy downloading and embedding
+for RAG.
 
 ## Contributing
 

--- a/docs/customization.qmd
+++ b/docs/customization.qmd
@@ -65,7 +65,7 @@ We find that mypy is an enormous time-saver, catching many errors early and grea
 
 ### Developing with LLMs
 
-The `.cursor/rules` folder contains a set of AI rules for working on this codebase in the Cursor IDE. We have also provided an [llms.txt](static/llms.txt) system prompt file for use with other agentic LLM workflows and exposed the full Markdown-formatted project documentation as a [single text file](docs/static/documentation.txt) for easy downloading and embedding for RAG.
+The `.cursor/rules` folder contains a set of AI rules for working on this codebase in the Cursor IDE. We have also exposed the full Markdown-formatted project documentation as a [single text file](docs/static/documentation.txt) for easy downloading and embedding for RAG.
 
 ## Application architecture
 

--- a/docs/static/documentation.txt
+++ b/docs/static/documentation.txt
@@ -205,11 +205,7 @@ with open(output_path, 'w', encoding='utf-8') as f:
     f.write(final_content)
 ```
 
-In line with the [llms.txt standard](https://llmstxt.org/), we have provided a Markdown-formatted prompt—designed to help LLM agents understand how to work with this template—as a text file: [llms.txt](docs/static/llms.txt).
-
-One use case for this file, if using the Cursor IDE, is to rename it to `.cursorrules` and place it in your project directory (see the [Cursor docs](https://docs.cursor.com/context/rules-for-ai) on this for more information). Alternatively, you could use it as a custom system prompt in the web interface for ChatGPT, Claude, or the LLM of your choice.
-
-We have also exposed the full Markdown-formatted project documentation as a [single text file](docs/static/documentation.txt) for easy downloading and embedding for RAG workflows.
+The `.cursor/rules` folder contains a set of AI rules for working on this codebase in the Cursor IDE. We have also exposed the full Markdown-formatted project documentation as a [single text file](docs/static/documentation.txt) for easy downloading and embedding for RAG.
 
 ## Contributing
 
@@ -643,11 +639,7 @@ We find that mypy is an enormous time-saver, catching many errors early and grea
 
 ### Developing with LLMs
 
-In line with the [llms.txt standard](https://llmstxt.org/), we have provided a Markdown-formatted prompt—designed to help LLM agents understand how to work with this template—as a text file: [llms.txt](static/llms.txt).
-
-One use case for this file, if using the Cursor IDE, is to rename it to `.cursorrules` and place it in your project directory (see the [Cursor docs](https://docs.cursor.com/context/rules-for-ai) on this for more information). Alternatively, you could use it as a custom system prompt in the web interface for ChatGPT, Claude, or the LLM of your choice.
-
-We have also exposed the full Markdown-formatted project documentation as a [single text file](static/documentation.txt) for easy downloading and embedding for RAG workflows.
+The `.cursor/rules` folder contains a set of AI rules for working on this codebase in the Cursor IDE. We have also exposed the full Markdown-formatted project documentation as a [single text file](static/documentation.txt) for easy downloading and embedding for RAG.
 
 ## Application architecture
 

--- a/index.qmd
+++ b/index.qmd
@@ -207,7 +207,7 @@ with open(output_path, 'w', encoding='utf-8') as f:
     f.write(final_content)
 ```
 
-The `.cursor/rules` folder contains a set of AI rules for working on this codebase in the Cursor IDE. We have also provided an [llms.txt](static/llms.txt) system prompt file for use with other agentic LLM workflows and exposed the full Markdown-formatted project documentation as a [single text file](docs/static/documentation.txt) for easy downloading and embedding for RAG.
+The `.cursor/rules` folder contains a set of AI rules for working on this codebase in the Cursor IDE. We have also exposed the full Markdown-formatted project documentation as a [single text file](docs/static/documentation.txt) for easy downloading and embedding for RAG.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Removes dead links and references to llms.txt from documentation
- Updates "Developing with LLMs" sections to only mention `.cursor/rules` and `documentation.txt`

Closes #128

## Test plan
- [x] Verify no remaining references to llms.txt in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)