### PR TITLE
Make user avatar its own data model

### DIFF
--- a/routers/core/user.py
+++ b/routers/core/user.py
@@ -4,7 +4,7 @@ from sqlmodel import Session, select
 from typing import Optional, List
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import selectinload
-from utils.core.models import User, DataIntegrityError, Organization
+from utils.core.models import User, UserAvatar, DataIntegrityError, Organization
 from utils.core.dependencies import get_authenticated_user, get_user_with_relations, get_session
 from utils.core.images import validate_and_process_image, MAX_FILE_SIZE, MIN_DIMENSION, MAX_DIMENSION, ALLOWED_CONTENT_TYPES
 from utils.core.enums import ValidPermissions
@@ -55,13 +55,20 @@ async def update_profile(
     if avatar_file:
         avatar_data = await avatar_file.read()
         avatar_content_type = avatar_file.content_type
-        
+
         processed_image, content_type = validate_and_process_image(
             avatar_data,
             avatar_content_type
         )
-        user.avatar_data = processed_image
-        user.avatar_content_type = content_type
+        if user.avatar:
+            user.avatar.avatar_data = processed_image
+            user.avatar.avatar_content_type = content_type
+        else:
+            user.avatar = UserAvatar(
+                user_id=user.id,
+                avatar_data=processed_image,
+                avatar_content_type=content_type
+            )
 
     # Update user details
     user.name = name
@@ -76,14 +83,14 @@ async def get_avatar(
     user: User = Depends(get_authenticated_user)
 ):
     """Serve avatar image from database"""
-    if not user.avatar_data:
+    if not user.avatar:
         raise DataIntegrityError(
             resource="User avatar"
         )
 
     return Response(
-        content=user.avatar_data,
-        media_type=user.avatar_content_type
+        content=user.avatar.avatar_data,
+        media_type=user.avatar.avatar_content_type
     )
 
 

--- a/templates/base/partials/header.html
+++ b/templates/base/partials/header.html
@@ -24,7 +24,7 @@
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <button class="profile-button btn p-0 border-0 bg-transparent">
-                            {% if user.avatar_data %}
+                            {% if user.avatar %}
                                 <img src="{{ url_for('get_avatar') }}" alt="User Avatar" class="d-inline-block align-top" width="30" height="30" style="border-radius: 50%;">
                             {% else %}
                                 {{ render_silhouette() }}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -30,7 +30,7 @@
             <p><strong>Email:</strong> {{ user.account.email }}</p>
             <!-- Display user avatar or silhouette if no avatar is available -->
             <div class="mb-3">
-                {% if user.avatar_data %}
+                {% if user.avatar %}
                     <img src="{{ url_for('get_avatar') }}" alt="User Avatar" class="img-thumbnail" width="150">
                 {% else %}
                     {{ render_silhouette(width=150, height=150) }}

--- a/tests/routers/core/test_user.py
+++ b/tests/routers/core/test_user.py
@@ -84,8 +84,9 @@ def test_update_profile_authorized(
     # Verify changes in database
     session.refresh(test_user)
     assert test_user.name == "Updated Name"
-    assert test_user.avatar_data == MOCK_IMAGE_DATA
-    assert test_user.avatar_content_type == MOCK_CONTENT_TYPE
+    assert test_user.avatar is not None
+    assert test_user.avatar.avatar_data == MOCK_IMAGE_DATA
+    assert test_user.avatar.avatar_content_type == MOCK_CONTENT_TYPE
 
     # Verify mock was called correctly
     mock_validate.assert_called_once()

--- a/utils/core/dependencies.py
+++ b/utils/core/dependencies.py
@@ -346,4 +346,8 @@ async def get_user_from_request(request: Request) -> Optional[User]:
             # The user will need to make another request to get new tokens.
             pass
 
+        if user:
+            # Eagerly load avatar so it's available after the session closes
+            _ = user.avatar
+
         return user

--- a/utils/core/models.py
+++ b/utils/core/models.py
@@ -114,12 +114,17 @@ class RolePermissionLink(SQLModel, table=True):
 
 class UserBase(SQLModel):
     name: Optional[str] = None
-    avatar_data: Optional[bytes] = Field(
-        default=None, sa_column=Column(LargeBinary)
-    )
-    avatar_content_type: Optional[str] = Field(
-        default=None
-    )
+
+
+class UserAvatar(SQLModel, table=True):
+    __tablename__ = "useravatar"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", unique=True, index=True)
+    avatar_data: bytes = Field(sa_column=Column(LargeBinary, nullable=False))
+    avatar_content_type: str
+
+    user: Mapped["User"] = Relationship(back_populates="avatar")
 
 
 # TODO: Prevent deleting a user who is sole owner of an organization
@@ -132,6 +137,13 @@ class User(UserBase, table=True):
     account_id: Optional[int] = Field(foreign_key="private.account.id", unique=True)
     account: Mapped[Optional[Account]] = Relationship(
         back_populates="user"
+    )
+    avatar: Mapped[Optional["UserAvatar"]] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={
+            "cascade": "all, delete-orphan",
+            "uselist": False
+        }
     )
     roles: Mapped[List["Role"]] = Relationship(
         back_populates="users",


### PR DESCRIPTION
The main motivation is performance: storing avatar_data (binary image blobs) directly on the User model means every query that loads a User also loads the potentially large image bytes — even when you only need the user's name or email.

With a separate UserAvatar model:

- Lazy/selective loading — the blob is only fetched from the database when you actually need the avatar. Queries like "get all users in an organization" won't pull megabytes of image data unnecessarily.
- Cleaner User table — the user table stays narrow and fast to scan. Large binary columns can bloat row storage and slow down index scans even when the column value is NULL.
- Easier to extend — if you later want multiple avatars, avatar history, or to move avatar storage to S3 (storing just a URL), the isolated model is easier to modify without touching the core User model.
- Separation of concerns — identity/profile data vs. media assets are logically distinct things.

The tradeoff is a JOIN when you do need the avatar, but that's a cheap indexed lookup on user_id.