### PR TITLE
Add auth rate limiting and harden forgot-password behavior

### DIFF
--- a/exceptions/http_exceptions.py
+++ b/exceptions/http_exceptions.py
@@ -1,6 +1,16 @@
 from fastapi import HTTPException, status
 from utils.core.enums import ValidPermissions
 
+class RateLimitError(HTTPException):
+    """Raised when a client exceeds the allowed request rate."""
+    def __init__(self, retry_after: int = 60):
+        self.retry_after = retry_after
+        super().__init__(
+            status_code=429,
+            detail="Too many attempts. Please try again later."
+        )
+
+
 class EmailAlreadyRegisteredError(HTTPException):
     def __init__(self):
         super().__init__(

--- a/main.py
+++ b/main.py
@@ -17,7 +17,8 @@ from utils.htmx import is_htmx_request
 from exceptions.http_exceptions import (
     AuthenticationError,
     PasswordValidationError,
-    CredentialsError
+    CredentialsError,
+    RateLimitError
 )
 from exceptions.exceptions import (
     NeedsNewTokens
@@ -72,6 +73,29 @@ async def authentication_error_handler(request: Request, exc: AuthenticationErro
         url=app.url_path_for("read_login"),
         status_code=status.HTTP_303_SEE_OTHER
     )
+
+
+# Handle RateLimitError (429 Too Many Requests)
+@app.exception_handler(RateLimitError)
+async def rate_limit_error_handler(request: Request, exc: RateLimitError):
+    if is_htmx_request(request):
+        response = templates.TemplateResponse(
+            request,
+            "base/partials/toast.html",
+            {"message": exc.detail, "level": "danger"},
+            status_code=429,
+        )
+        response.headers["Retry-After"] = str(exc.retry_after)
+        return response
+    user = await get_user_from_request(request)
+    response = templates.TemplateResponse(
+        request,
+        "errors/error.html",
+        {"status_code": 429, "detail": exc.detail, "user": user},
+        status_code=429,
+    )
+    response.headers["Retry-After"] = str(exc.retry_after)
+    return response
 
 
 # Handle CredentialsError (invalid email/password) with toast for HTMX

--- a/routers/core/account.py
+++ b/routers/core/account.py
@@ -19,7 +19,7 @@ from utils.core.auth import (
     create_access_token,
     create_refresh_token,
     validate_token,
-    send_reset_email,
+    send_reset_email_task,
     send_email_update_confirmation
 )
 from utils.core.dependencies import (
@@ -41,6 +41,14 @@ from routers.core.dashboard import router as dashboard_router
 from routers.core.user import router as user_router
 from routers.core.organization import router as org_router
 from utils.core.invitations import process_invitation
+from utils.core.rate_limit import (
+    check_login_ip_rate_limit,
+    check_login_email_rate_limit,
+    check_register_ip_rate_limit,
+    check_forgot_password_ip_rate_limit,
+    check_forgot_password_email_rate_limit,
+    login_email_limiter,
+)
 from utils.htmx import is_htmx_request
 logger = getLogger("uvicorn.error")
 
@@ -220,6 +228,8 @@ async def delete_account(
 
 @router.post("/register", response_class=RedirectResponse)
 async def register(
+    request: Request,
+    _ip_check: None = Depends(check_register_ip_rate_limit),
     name: str = Form(...),
     email: EmailStr = Form(...),
     session: Session = Depends(get_session),
@@ -336,6 +346,9 @@ async def register(
 
 @router.post("/login", response_class=RedirectResponse)
 async def login(
+    request: Request,
+    _ip_check: None = Depends(check_login_ip_rate_limit),
+    _email_check: EmailStr = Depends(check_login_email_rate_limit),
     account_and_session: Tuple[Account, Session] = Depends(get_account_from_credentials),
     invitation_token: Optional[str] = Form(None)
 ) -> RedirectResponse:
@@ -343,6 +356,10 @@ async def login(
     Log in a user with valid credentials and process invitation if token is provided.
     """
     account, session = account_and_session
+
+    # Successful login: reset the per-email rate limiter so legitimate users
+    # are not penalised for earlier mistyped attempts.
+    login_email_limiter.reset(f"email:{account.email.lower().strip()}")
 
     # Default redirect target
     redirect_url = dashboard_router.url_path_for("read_dashboard")
@@ -478,7 +495,8 @@ async def refresh_token(
 async def forgot_password(
     background_tasks: BackgroundTasks,
     request: Request,
-    email: EmailStr = Form(...),
+    _ip_check: None = Depends(check_forgot_password_ip_rate_limit),
+    email: EmailStr = Depends(check_forgot_password_email_rate_limit),
     session: Session = Depends(get_session)
 ):
     """
@@ -489,7 +507,7 @@ async def forgot_password(
         Account.email == email)).one_or_none()
 
     if account:
-        background_tasks.add_task(send_reset_email, email, session)
+        background_tasks.add_task(send_reset_email_task, email)
 
     # Get the referer header, default to /forgot_password if not present
     referer = request.headers.get("referer", "/forgot_password")

--- a/tests/routers/core/test_account.py
+++ b/tests/routers/core/test_account.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 from starlette.datastructures import URLPath
 from sqlmodel import Session, select
@@ -14,6 +15,27 @@ from utils.core.auth import (
     validate_token,
     get_password_hash
 )
+from utils.core.rate_limit import (
+    login_ip_limiter,
+    login_email_limiter,
+    register_ip_limiter,
+    forgot_password_ip_limiter,
+    forgot_password_email_limiter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiters():
+    """Reset all rate limiter state between tests to avoid cross-test pollution."""
+    yield
+    for limiter in (
+        login_ip_limiter,
+        login_email_limiter,
+        register_ip_limiter,
+        forgot_password_ip_limiter,
+        forgot_password_email_limiter,
+    ):
+        limiter._attempts.clear()
 
 # --- API Endpoint Tests ---
 
@@ -237,6 +259,34 @@ def test_password_reset_email_url(unauth_client: TestClient, session: Session, t
     assert query_params["token"][0] == reset_token.token
 
 
+def test_forgot_password_does_not_send_second_email_while_token_is_active(
+    unauth_client: TestClient,
+    session: Session,
+    test_account: Account,
+    mock_resend_send,
+):
+    """Forgot-password preserves the existing one-hour token/send suppression."""
+    first_response = unauth_client.post(
+        app.url_path_for("forgot_password"),
+        data={"email": test_account.email},
+        follow_redirects=False,
+    )
+    assert first_response.status_code == 303
+
+    second_response = unauth_client.post(
+        app.url_path_for("forgot_password"),
+        data={"email": test_account.email},
+        follow_redirects=False,
+    )
+    assert second_response.status_code == 303
+
+    tokens = session.exec(
+        select(PasswordResetToken).where(PasswordResetToken.account_id == test_account.id)
+    ).all()
+    assert len(tokens) == 1
+    assert mock_resend_send.call_count == 1
+
+
 def test_request_email_update_success(auth_client: TestClient, test_account: Account, mock_resend_send):
     """Test successful email update request"""
     new_email = "newemail@example.com"
@@ -370,7 +420,7 @@ def test_confirm_email_update_used_token(unauth_client: TestClient, session: Ses
     )
     session.add(used_token)
     session.commit()
-    
+
     response = unauth_client.get(
         app.url_path_for("confirm_email_update"),
         params={
@@ -379,10 +429,125 @@ def test_confirm_email_update_used_token(unauth_client: TestClient, session: Ses
             "new_email": "new@example.com"
         }
     )
-    
+
     assert response.status_code == 401
     assert "Invalid or expired" in response.text
-    
+
     # Verify email was not updated
     session.refresh(test_account)
     assert test_account.email == "test@example.com"
+
+
+# --- Rate Limiting Tests ---
+
+
+def test_login_ip_rate_limit(unauth_client: TestClient, test_account: Account):
+    """Login returns 429 after exceeding IP rate limit."""
+    for _ in range(login_ip_limiter.max_attempts):
+        unauth_client.post(
+            app.url_path_for("login"),
+            data={"email": test_account.email, "password": "WrongPass123!@#"},
+        )
+
+    response = unauth_client.post(
+        app.url_path_for("login"),
+        data={"email": test_account.email, "password": "WrongPass123!@#"},
+    )
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers
+
+
+def test_login_email_rate_limit(unauth_client: TestClient, test_account: Account):
+    """Login returns 429 after exceeding per-email rate limit."""
+    for _ in range(login_email_limiter.max_attempts):
+        unauth_client.post(
+            app.url_path_for("login"),
+            data={"email": test_account.email, "password": "WrongPass123!@#"},
+        )
+
+    response = unauth_client.post(
+        app.url_path_for("login"),
+        data={"email": test_account.email, "password": "WrongPass123!@#"},
+    )
+    assert response.status_code == 429
+
+
+def test_login_success_resets_email_limiter(unauth_client: TestClient, test_account: Account):
+    """Successful login resets the per-email rate limiter."""
+    # Use up all but one email attempt
+    for _ in range(login_email_limiter.max_attempts - 1):
+        unauth_client.post(
+            app.url_path_for("login"),
+            data={"email": test_account.email, "password": "WrongPass123!@#"},
+        )
+    assert login_email_limiter.remaining(f"email:{test_account.email.lower().strip()}") == 1
+
+    # Successful login should reset the counter
+    response = unauth_client.post(
+        app.url_path_for("login"),
+        data={"email": test_account.email, "password": "Test123!@#"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+    # Verify the limiter was reset — full allowance available
+    assert login_email_limiter.remaining(f"email:{test_account.email.lower().strip()}") == login_email_limiter.max_attempts
+
+
+def test_register_ip_rate_limit(unauth_client: TestClient, session: Session):
+    """Register returns 429 after exceeding IP rate limit."""
+    for i in range(register_ip_limiter.max_attempts):
+        unauth_client.post(
+            app.url_path_for("register"),
+            data={
+                "name": f"User{i}",
+                "email": f"user{i}@example.com",
+                "password": "Test123!@#",
+                "confirm_password": "Test123!@#",
+            },
+            follow_redirects=False,
+        )
+
+    response = unauth_client.post(
+        app.url_path_for("register"),
+        data={
+            "name": "Blocked",
+            "email": "blocked@example.com",
+            "password": "Test123!@#",
+            "confirm_password": "Test123!@#",
+        },
+    )
+    assert response.status_code == 429
+
+
+def test_forgot_password_ip_rate_limit(unauth_client: TestClient):
+    """Forgot password returns 429 after exceeding IP rate limit."""
+    for i in range(forgot_password_ip_limiter.max_attempts):
+        unauth_client.post(
+            app.url_path_for("forgot_password"),
+            data={"email": f"user{i}@example.com"},
+            follow_redirects=False,
+        )
+
+    response = unauth_client.post(
+        app.url_path_for("forgot_password"),
+        data={"email": "extra@example.com"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 429
+
+
+def test_forgot_password_email_rate_limit(unauth_client: TestClient, test_account: Account, mock_resend_send):
+    """Forgot password returns 429 after exceeding per-email rate limit."""
+    for _ in range(forgot_password_email_limiter.max_attempts):
+        unauth_client.post(
+            app.url_path_for("forgot_password"),
+            data={"email": test_account.email},
+            follow_redirects=False,
+        )
+
+    response = unauth_client.post(
+        app.url_path_for("forgot_password"),
+        data={"email": test_account.email},
+    )
+    assert response.status_code == 429

--- a/tests/test_htmx.py
+++ b/tests/test_htmx.py
@@ -11,6 +11,27 @@ import pytest
 from starlette.requests import Request
 from tests.conftest import htmx_headers, is_html_partial
 from utils.htmx import is_htmx_request
+from utils.core.rate_limit import (
+    login_ip_limiter,
+    login_email_limiter,
+    register_ip_limiter,
+    forgot_password_ip_limiter,
+    forgot_password_email_limiter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiters():
+    """Reset all rate limiter state between tests."""
+    yield
+    for limiter in (
+        login_ip_limiter,
+        login_email_limiter,
+        register_ip_limiter,
+        forgot_password_ip_limiter,
+        forgot_password_email_limiter,
+    ):
+        limiter._attempts.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -326,3 +347,47 @@ def test_update_role_htmx_refreshes_modal_container(auth_client_owner, test_orga
     # OOB-refreshed modal container includes updated edit modal title
     assert "Edit Role: NewName" in response.text
     assert 'id="role-modals-container"' in response.text
+
+
+# ---------------------------------------------------------------------------
+# 5.1 — Rate limit 429 toast responses
+# ---------------------------------------------------------------------------
+
+def test_login_rate_limit_htmx_returns_toast(unauth_client):
+    """Rate-limited HTMX login returns a 429 toast partial with Retry-After."""
+    for _ in range(login_ip_limiter.max_attempts):
+        unauth_client.post(
+            "/account/login",
+            data={"email": "nobody@example.com", "password": "wrongpass"},
+            headers=htmx_headers(),
+        )
+
+    response = unauth_client.post(
+        "/account/login",
+        data={"email": "nobody@example.com", "password": "wrongpass"},
+        headers=htmx_headers(),
+    )
+    assert response.status_code == 429
+    assert "toast" in response.text
+    assert "<!DOCTYPE html>" not in response.text
+    assert "Retry-After" in response.headers
+
+
+def test_forgot_password_rate_limit_htmx_returns_toast(unauth_client):
+    """Rate-limited HTMX forgot-password returns a 429 toast partial."""
+    for _ in range(forgot_password_ip_limiter.max_attempts):
+        unauth_client.post(
+            "/account/forgot_password",
+            data={"email": f"user@example.com"},
+            headers=htmx_headers(),
+            follow_redirects=False,
+        )
+
+    response = unauth_client.post(
+        "/account/forgot_password",
+        data={"email": "user@example.com"},
+        headers=htmx_headers(),
+    )
+    assert response.status_code == 429
+    assert "toast" in response.text
+    assert "<!DOCTYPE html>" not in response.text

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -1,0 +1,161 @@
+import importlib
+import time
+from unittest.mock import patch
+
+import utils.core.rate_limit as rate_limit_module
+from utils.core.rate_limit import RateLimitWindow
+
+
+# ---------------------------------------------------------------------------
+# RateLimitWindow — core behaviour
+# ---------------------------------------------------------------------------
+
+def test_allows_requests_under_limit():
+    limiter = RateLimitWindow(max_attempts=3, window_seconds=60)
+    for _ in range(3):
+        is_limited, _ = limiter.check("key")
+        assert not is_limited
+        limiter.record("key")
+
+
+def test_blocks_once_limit_exceeded():
+    limiter = RateLimitWindow(max_attempts=3, window_seconds=60)
+    for _ in range(3):
+        limiter.record("key")
+    is_limited, retry_after = limiter.check("key")
+    assert is_limited
+    assert retry_after >= 1
+
+
+def test_different_keys_are_independent():
+    limiter = RateLimitWindow(max_attempts=2, window_seconds=60)
+    limiter.record("a")
+    limiter.record("a")
+    assert limiter.check("a")[0] is True
+    assert limiter.check("b")[0] is False
+
+
+def test_remaining_decreases():
+    limiter = RateLimitWindow(max_attempts=5, window_seconds=60)
+    assert limiter.remaining("key") == 5
+    limiter.record("key")
+    assert limiter.remaining("key") == 4
+    limiter.record("key")
+    assert limiter.remaining("key") == 3
+
+
+def test_reset_clears_key():
+    limiter = RateLimitWindow(max_attempts=2, window_seconds=60)
+    limiter.record("key")
+    limiter.record("key")
+    assert limiter.check("key")[0] is True
+    limiter.reset("key")
+    assert limiter.check("key")[0] is False
+    assert limiter.remaining("key") == 2
+
+
+def test_reset_nonexistent_key_is_noop():
+    limiter = RateLimitWindow(max_attempts=2, window_seconds=60)
+    limiter.reset("nonexistent")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Window expiry
+# ---------------------------------------------------------------------------
+
+def test_unblocks_after_window_expiry():
+    """Simulate time passing so that old attempts fall outside the window."""
+    limiter = RateLimitWindow(max_attempts=2, window_seconds=10)
+
+    base_time = time.monotonic()
+
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time):
+        limiter.record("key")
+        limiter.record("key")
+
+    # Still within window
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time + 5):
+        assert limiter.check("key")[0] is True
+
+    # After the window expires
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time + 11):
+        assert limiter.check("key")[0] is False
+        assert limiter.remaining("key") == 2
+
+
+def test_retry_after_is_positive_and_decreases():
+    limiter = RateLimitWindow(max_attempts=1, window_seconds=30)
+
+    base_time = time.monotonic()
+
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time):
+        limiter.record("key")
+
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time + 5):
+        is_limited, retry_after = limiter.check("key")
+        assert is_limited
+        assert retry_after == 25
+
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time + 20):
+        is_limited, retry_after = limiter.check("key")
+        assert is_limited
+        assert retry_after == 10
+
+
+# ---------------------------------------------------------------------------
+# Prune
+# ---------------------------------------------------------------------------
+
+def test_prune_removes_stale_keys():
+    limiter = RateLimitWindow(max_attempts=2, window_seconds=10)
+
+    base_time = time.monotonic()
+
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time):
+        limiter.record("stale_key")
+        limiter.record("fresh_key")
+
+    # Advance past window for stale_key
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time + 11):
+        # Record fresh_key again so it still has in-window attempts
+        limiter.record("fresh_key")
+        limiter.prune()
+
+    assert "stale_key" not in limiter._attempts
+    assert "fresh_key" in limiter._attempts
+
+
+def test_prune_on_empty_store():
+    limiter = RateLimitWindow(max_attempts=2, window_seconds=10)
+    limiter.prune()  # should not raise
+
+
+def test_access_triggers_periodic_global_prune():
+    limiter = RateLimitWindow(
+        max_attempts=2,
+        window_seconds=10,
+        prune_interval_seconds=5,
+    )
+
+    base_time = time.monotonic()
+
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time):
+        limiter.record("stale_key")
+
+    with patch("utils.core.rate_limit.time.monotonic", return_value=base_time + 11):
+        limiter.record("fresh_key")
+
+    assert "stale_key" not in limiter._attempts
+    assert "fresh_key" in limiter._attempts
+
+
+def test_module_limiters_honor_env_configuration(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv("LOGIN_IP_LIMIT", "17")
+        m.setenv("FORGOT_PASSWORD_EMAIL_WINDOW_SECONDS", "91")
+        importlib.reload(rate_limit_module)
+
+        assert rate_limit_module.login_ip_limiter.max_attempts == 17
+        assert rate_limit_module.forgot_password_email_limiter.window_seconds == 91
+
+    importlib.reload(rate_limit_module)

--- a/utils/core/auth.py
+++ b/utils/core/auth.py
@@ -12,6 +12,7 @@ from typing import Optional
 from jinja2.environment import Template
 from fastapi.templating import Jinja2Templates
 from fastapi import Cookie
+from utils.core.db import create_engine, get_connection_url
 from utils.core.models import PasswordResetToken, EmailUpdateToken, Account
 
 logger = logging.getLogger(__name__)
@@ -216,6 +217,18 @@ def send_reset_email(email: str, session: Session) -> None:
             session.rollback()
     else:
         logger.debug("No account found with the provided email.")
+
+
+def send_reset_email_task(email: str) -> None:
+    """
+    Background-task wrapper that creates its own session.
+
+    FastAPI background tasks should not reuse request-scoped resources from
+    `yield` dependencies, because cleanup may run before the task executes.
+    """
+    engine = create_engine(get_connection_url())
+    with Session(engine) as session:
+        send_reset_email(email, session)
 
 
 def generate_email_update_url(account_id: int, token: str, new_email: str) -> str:

--- a/utils/core/rate_limit.py
+++ b/utils/core/rate_limit.py
@@ -1,0 +1,213 @@
+import os
+import time
+import threading
+import math
+from logging import getLogger
+from typing import Tuple
+
+from fastapi import Request, Form
+from pydantic import EmailStr
+from dotenv import load_dotenv
+
+logger = getLogger("uvicorn.error")
+load_dotenv()
+
+
+class RateLimitWindow:
+    """
+    Thread-safe sliding window rate limiter with bounded in-memory state.
+
+    Tracks timestamps of attempts per key. Rejects requests that exceed
+    `max_attempts` within `window_seconds`. Stale keys are pruned on
+    every access and via an explicit `prune()` method.
+    """
+
+    def __init__(
+        self,
+        max_attempts: int,
+        window_seconds: int,
+        prune_interval_seconds: int = 30,
+    ):
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self.prune_interval_seconds = prune_interval_seconds
+        self._attempts: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+        self._next_prune_at = time.monotonic() + prune_interval_seconds
+
+    def _cleanup_key(self, key: str, now: float) -> None:
+        """Remove expired timestamps for a single key. Delete the key if empty."""
+        cutoff = now - self.window_seconds
+        if key in self._attempts:
+            self._attempts[key] = [t for t in self._attempts[key] if t > cutoff]
+            if not self._attempts[key]:
+                del self._attempts[key]
+
+    def _prune_stale_keys(self, now: float) -> None:
+        """Remove stale keys across the whole store."""
+        cutoff = now - self.window_seconds
+        stale_keys = [
+            key for key, timestamps in self._attempts.items()
+            if all(timestamp <= cutoff for timestamp in timestamps)
+        ]
+        for key in stale_keys:
+            del self._attempts[key]
+
+    def _maybe_prune(self, now: float) -> None:
+        """
+        Opportunistically prune stale one-off keys during normal access.
+
+        This prevents memory from growing without bound when many keys are
+        never touched again after their window expires.
+        """
+        if now < self._next_prune_at:
+            return
+        self._prune_stale_keys(now)
+        self._next_prune_at = now + self.prune_interval_seconds
+
+    def check(self, key: str) -> Tuple[bool, int]:
+        """
+        Check whether a key is currently rate-limited.
+
+        Returns:
+            (is_limited, retry_after_seconds)
+            retry_after_seconds is 0 when not limited.
+        """
+        now = time.monotonic()
+        with self._lock:
+            self._maybe_prune(now)
+            self._cleanup_key(key, now)
+            attempts = self._attempts.get(key, [])
+            if len(attempts) >= self.max_attempts:
+                oldest_relevant = attempts[0]
+                retry_after = math.ceil((oldest_relevant + self.window_seconds) - now)
+                return True, max(retry_after, 1)
+            return False, 0
+
+    def record(self, key: str) -> None:
+        """Record an attempt for a key."""
+        now = time.monotonic()
+        with self._lock:
+            self._maybe_prune(now)
+            self._cleanup_key(key, now)
+            if key not in self._attempts:
+                self._attempts[key] = []
+            self._attempts[key].append(now)
+
+    def remaining(self, key: str) -> int:
+        """Return the number of attempts remaining before the key is limited."""
+        now = time.monotonic()
+        with self._lock:
+            self._maybe_prune(now)
+            self._cleanup_key(key, now)
+            return max(0, self.max_attempts - len(self._attempts.get(key, [])))
+
+    def reset(self, key: str) -> None:
+        """Clear all recorded attempts for a key."""
+        with self._lock:
+            self._attempts.pop(key, None)
+
+    def prune(self) -> None:
+        """Remove all stale keys. Call periodically to bound memory growth."""
+        now = time.monotonic()
+        with self._lock:
+            self._prune_stale_keys(now)
+            self._next_prune_at = now + self.prune_interval_seconds
+
+
+# --- Configuration helpers ---
+
+def _int_env(name: str, default: int) -> int:
+    val = os.environ.get(name)
+    if val is not None:
+        try:
+            return int(val)
+        except ValueError:
+            logger.warning(f"Invalid integer for {name}={val!r}, using default {default}")
+    return default
+
+
+# --- Shared limiter instances ---
+
+login_ip_limiter = RateLimitWindow(
+    max_attempts=_int_env("LOGIN_IP_LIMIT", 10),
+    window_seconds=_int_env("LOGIN_IP_WINDOW_SECONDS", 60),
+)
+login_email_limiter = RateLimitWindow(
+    max_attempts=_int_env("LOGIN_EMAIL_LIMIT", 5),
+    window_seconds=_int_env("LOGIN_EMAIL_WINDOW_SECONDS", 60),
+)
+register_ip_limiter = RateLimitWindow(
+    max_attempts=_int_env("REGISTER_IP_LIMIT", 5),
+    window_seconds=_int_env("REGISTER_IP_WINDOW_SECONDS", 60),
+)
+forgot_password_ip_limiter = RateLimitWindow(
+    max_attempts=_int_env("FORGOT_PASSWORD_IP_LIMIT", 5),
+    window_seconds=_int_env("FORGOT_PASSWORD_IP_WINDOW_SECONDS", 60),
+)
+forgot_password_email_limiter = RateLimitWindow(
+    max_attempts=_int_env("FORGOT_PASSWORD_EMAIL_LIMIT", 3),
+    window_seconds=_int_env("FORGOT_PASSWORD_EMAIL_WINDOW_SECONDS", 60),
+)
+
+
+# --- Dependency helpers ---
+
+def get_client_ip(request: Request) -> str:
+    """
+    Extract client IP from the request.
+
+    Uses request.client.host only. Does NOT trust X-Forwarded-For
+    because this app has no trusted-proxy middleware.
+    """
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+def _enforce_rate_limit(limiter: RateLimitWindow, key: str, scope: str) -> int:
+    """
+    Check the limiter for the given key. If limited, raise RateLimitError.
+    Otherwise, record the attempt and return.
+
+    Returns the retry_after value (0 when not limited).
+    """
+    from exceptions.http_exceptions import RateLimitError
+
+    is_limited, retry_after = limiter.check(key)
+    if is_limited:
+        logger.warning(f"Rate limit exceeded: scope={scope} key={key}")
+        raise RateLimitError(retry_after=retry_after)
+    limiter.record(key)
+    return 0
+
+
+# --- Per-endpoint FastAPI dependencies ---
+
+def check_login_ip_rate_limit(request: Request) -> None:
+    ip = get_client_ip(request)
+    _enforce_rate_limit(login_ip_limiter, f"ip:{ip}", "login_ip")
+
+
+def check_login_email_rate_limit(email: EmailStr = Form(...)) -> EmailStr:
+    normalized = email.lower().strip()
+    _enforce_rate_limit(login_email_limiter, f"email:{normalized}", "login_email")
+    return email
+
+
+def check_register_ip_rate_limit(request: Request) -> None:
+    ip = get_client_ip(request)
+    _enforce_rate_limit(register_ip_limiter, f"ip:{ip}", "register_ip")
+
+
+def check_forgot_password_ip_rate_limit(request: Request) -> None:
+    ip = get_client_ip(request)
+    _enforce_rate_limit(forgot_password_ip_limiter, f"ip:{ip}", "forgot_password_ip")
+
+
+def check_forgot_password_email_rate_limit(email: EmailStr = Form(...)) -> EmailStr:
+    normalized = email.lower().strip()
+    _enforce_rate_limit(
+        forgot_password_email_limiter, f"email:{normalized}", "forgot_password_email"
+    )
+    return email


### PR DESCRIPTION
## Summary
- add in-memory rate limiters for login, register, and forgot-password flows
- add 429 exception handling and endpoint/HTMX coverage for rate-limited requests
- preserve forgot-password background task safety, env-backed limiter config, and stale-key pruning

## Testing
- uv run pytest
