### PR TITLE
Set follow_redirects=False session-wide on TestClient

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def env_vars(monkeypatch):
         m.setenv("DB_PORT", os.getenv("DB_PORT", "5432"))
         m.setenv("DB_USER", os.getenv("DB_USER", "postgres"))
         m.setenv("DB_PASSWORD", os.getenv("DB_PASSWORD", "postgres"))
-        m.setenv("SECRET_KEY", "testsecretkey")
+        m.setenv("SECRET_KEY", "testsecretkey-that-is-at-least-32-bytes-long")
         m.setenv("HOST_NAME", "Test Organization")
         m.setenv("DB_NAME", "webapp-test-db")
         m.setenv("RESEND_API_KEY", "test")
@@ -102,7 +102,7 @@ def unauth_client(session: Session) -> Generator[TestClient, None, None]:
     """
     Provides a TestClient instance without authentication.
     """
-    client = TestClient(app)
+    client = TestClient(app, follow_redirects=False)
     yield client
 
 
@@ -111,7 +111,7 @@ def auth_client(session: Session, test_account: Account, test_user: User) -> Gen
     """
     Provides a TestClient instance with valid authentication tokens.
     """
-    client = TestClient(app)
+    client = TestClient(app, follow_redirects=False)
 
     # Create and set valid tokens
     access_token = create_access_token({"sub": test_account.email})
@@ -275,8 +275,8 @@ def non_member_user(session: Session) -> User:
 @pytest.fixture
 def auth_client_owner(session: Session, org_owner: User) -> Generator[TestClient, None, None]:
     """Provides a TestClient authenticated as the organization owner"""
-    client = TestClient(app)
-    
+    client = TestClient(app, follow_redirects=False)
+
     # Initialize tokens
     access_token = ""
     refresh_token = ""
@@ -295,8 +295,8 @@ def auth_client_owner(session: Session, org_owner: User) -> Generator[TestClient
 @pytest.fixture
 def auth_client_admin(session: Session, org_admin_user: User) -> Generator[TestClient, None, None]:
     """Provides a TestClient authenticated as an organization administrator"""
-    client = TestClient(app)
-    
+    client = TestClient(app, follow_redirects=False)
+
     # Initialize tokens
     access_token = ""
     refresh_token = ""
@@ -315,8 +315,8 @@ def auth_client_admin(session: Session, org_admin_user: User) -> Generator[TestC
 @pytest.fixture
 def auth_client_member(session: Session, org_member_user: User) -> Generator[TestClient, None, None]:
     """Provides a TestClient authenticated as the organization member"""
-    client = TestClient(app)
-    
+    client = TestClient(app, follow_redirects=False)
+
     # Initialize tokens
     access_token = ""
     refresh_token = ""
@@ -335,8 +335,8 @@ def auth_client_member(session: Session, org_member_user: User) -> Generator[Tes
 @pytest.fixture
 def auth_client_non_member(session: Session, non_member_user: User) -> Generator[TestClient, None, None]:
     """Provides a TestClient authenticated as a non-member"""
-    client = TestClient(app)
-    
+    client = TestClient(app, follow_redirects=False)
+
     # Initialize tokens
     access_token = ""
     refresh_token = ""
@@ -469,8 +469,8 @@ def existing_invitee_user(session: Session, existing_invitee_account: Account) -
 @pytest.fixture
 def auth_client_invitee(session: Session, existing_invitee_user: User) -> Generator[TestClient, None, None]:
     """Provides a TestClient authenticated as the existing_invitee_user."""
-    client = TestClient(app)
-    
+    client = TestClient(app, follow_redirects=False)
+
     # Initialize tokens
     access_token = ""
     refresh_token = ""

--- a/tests/routers/core/test_account.py
+++ b/tests/routers/core/test_account.py
@@ -55,11 +55,11 @@ def test_register_endpoint(unauth_client: TestClient, session: Session):
             "password": "NewPass123!@#",
             "confirm_password": "NewPass123!@#"
         },
-        follow_redirects=False
     )
-    
+
     # Just check the response status code
     assert response.status_code == 303
+    assert response.headers["location"] == str(app.url_path_for("read_dashboard"))
     
     # Verify the account was created
     account = session.exec(select(Account).where(Account.email == "new@example.com")).first()
@@ -79,9 +79,9 @@ def test_login_endpoint(unauth_client: TestClient, test_account: Account):
             "email": test_account.email,
             "password": "Test123!@#"
         },
-        follow_redirects=False
     )
     assert response.status_code == 303
+    assert response.headers["location"] == str(app.url_path_for("read_dashboard"))
 
     # Check if cookies are set
     cookies = response.cookies
@@ -99,9 +99,9 @@ def test_refresh_token_endpoint(auth_client: TestClient, test_account: Account):
 
     response = auth_client.post(
         app.url_path_for("refresh_token"),
-        follow_redirects=False
     )
     assert response.status_code == 303
+    assert response.headers["location"] == str(app.url_path_for("read_dashboard"))
 
     # Check for new tokens in headers
     cookie_headers = response.headers.get_list("set-cookie")
@@ -125,9 +125,9 @@ def test_password_reset_flow(unauth_client: TestClient, session: Session, test_a
     response = unauth_client.post(
         app.url_path_for("forgot_password"),
         data={"email": test_account.email},
-        follow_redirects=False
     )
     assert response.status_code == 303
+    assert response.headers["location"] == "/forgot_password?show_form=false"
 
     # Verify the email was "sent" with correct parameters
     mock_resend_send.assert_called_once()
@@ -167,9 +167,9 @@ def test_password_reset_flow(unauth_client: TestClient, session: Session, test_a
 def test_logout_endpoint(auth_client: TestClient):
     response = auth_client.get(
         app.url_path_for("logout"),
-        follow_redirects=False
     )
     assert response.status_code == 303
+    assert response.headers["location"] == "/"
 
     # Check for cookie deletion in headers
     cookie_headers = response.headers.get_list("set-cookie")
@@ -227,9 +227,9 @@ def test_password_reset_email_url(unauth_client: TestClient, session: Session, t
     response = unauth_client.post(
         app.url_path_for("forgot_password"),
         data={"email": test_account.email},
-        follow_redirects=False
     )
     assert response.status_code == 303
+    assert response.headers["location"] == "/forgot_password?show_form=false"
 
     # Get the reset token from the database
     reset_token = session.exec(select(PasswordResetToken)
@@ -269,16 +269,16 @@ def test_forgot_password_does_not_send_second_email_while_token_is_active(
     first_response = unauth_client.post(
         app.url_path_for("forgot_password"),
         data={"email": test_account.email},
-        follow_redirects=False,
     )
     assert first_response.status_code == 303
+    assert first_response.headers["location"] == "/forgot_password?show_form=false"
 
     second_response = unauth_client.post(
         app.url_path_for("forgot_password"),
         data={"email": test_account.email},
-        follow_redirects=False,
     )
     assert second_response.status_code == 303
+    assert second_response.headers["location"] == "/forgot_password?show_form=false"
 
     tokens = session.exec(
         select(PasswordResetToken).where(PasswordResetToken.account_id == test_account.id)
@@ -294,9 +294,8 @@ def test_request_email_update_success(auth_client: TestClient, test_account: Acc
     response = auth_client.post(
         app.url_path_for("request_email_update"),
         data={"email": test_account.email, "new_email": new_email},
-        follow_redirects=False
     )
-    
+
     assert response.status_code == 303
     assert f"{app.url_path_for('read_profile')}?email_update_requested=true" in response.headers["location"]
     
@@ -316,7 +315,6 @@ def test_request_email_update_same_email_returns_error_page(auth_client: TestCli
     response = auth_client.post(
         app.url_path_for("request_email_update"),
         data={"email": test_account.email, "new_email": test_account.email},
-        follow_redirects=False,
     )
 
     assert response.status_code == 401
@@ -349,10 +347,10 @@ def test_request_email_update_unauthenticated(unauth_client: TestClient):
     response = unauth_client.post(
         app.url_path_for("request_email_update"),
         data={"email": "test@example.com", "new_email": "new@example.com"},
-        follow_redirects=False
     )
-    
+
     assert response.status_code == 303  # Redirect to login
+    assert response.headers["location"] == str(app.url_path_for("read_login"))
 
 
 def test_confirm_email_update_success(unauth_client: TestClient, session: Session, test_account: Account):
@@ -371,7 +369,6 @@ def test_confirm_email_update_success(unauth_client: TestClient, session: Sessio
             "token": update_token.token,
             "new_email": new_email
         },
-        follow_redirects=False
     )
     
     assert response.status_code == 303
@@ -486,9 +483,9 @@ def test_login_success_resets_email_limiter(unauth_client: TestClient, test_acco
     response = unauth_client.post(
         app.url_path_for("login"),
         data={"email": test_account.email, "password": "Test123!@#"},
-        follow_redirects=False,
     )
     assert response.status_code == 303
+    assert response.headers["location"] == str(app.url_path_for("read_dashboard"))
 
     # Verify the limiter was reset — full allowance available
     assert login_email_limiter.remaining(f"email:{test_account.email.lower().strip()}") == login_email_limiter.max_attempts
@@ -505,7 +502,6 @@ def test_register_ip_rate_limit(unauth_client: TestClient, session: Session):
                 "password": "Test123!@#",
                 "confirm_password": "Test123!@#",
             },
-            follow_redirects=False,
         )
 
     response = unauth_client.post(
@@ -526,13 +522,11 @@ def test_forgot_password_ip_rate_limit(unauth_client: TestClient):
         unauth_client.post(
             app.url_path_for("forgot_password"),
             data={"email": f"user{i}@example.com"},
-            follow_redirects=False,
         )
 
     response = unauth_client.post(
         app.url_path_for("forgot_password"),
         data={"email": "extra@example.com"},
-        follow_redirects=False,
     )
     assert response.status_code == 429
 
@@ -543,7 +537,6 @@ def test_forgot_password_email_rate_limit(unauth_client: TestClient, test_accoun
         unauth_client.post(
             app.url_path_for("forgot_password"),
             data={"email": test_account.email},
-            follow_redirects=False,
         )
 
     response = unauth_client.post(

--- a/tests/routers/core/test_invitation.py
+++ b/tests/routers/core/test_invitation.py
@@ -277,7 +277,6 @@ def test_create_invitation_success(auth_client, inviter_user: User, test_organiz
             "role_id": str(member_role_id), # Form data is usually string
             "organization_id": str(test_organization.id) # Form data is usually string
         },
-        follow_redirects=False # Important for checking redirect
     )
 
     assert response.status_code == 303, f"Expected 303 redirect, got {response.status_code}. Response: {response.text}" # See Other redirect
@@ -327,7 +326,6 @@ def test_create_invitation_unauthorized(auth_client_member, test_user: User, tes
             "role_id": str(member_role.id),
             "organization_id": str(test_organization.id)
         },
-        follow_redirects=False
     )
 
     assert response.status_code == 403, f"Expected 403 Forbidden, got {response.status_code}. Response: {response.text}" # Forbidden
@@ -388,7 +386,6 @@ def test_create_invitation_for_existing_member(auth_client, inviter_user: User, 
             "role_id": str(member_role.id),
             "organization_id": str(test_organization.id)
         },
-        follow_redirects=False
     )
 
     # Expecting a 409 Conflict based on the plan
@@ -405,7 +402,6 @@ def test_create_invitation_duplicate_active(auth_client, inviter_user: User, exi
             "role_id": str(existing_invitation.role_id),
             "organization_id": str(existing_invitation.organization_id)
         },
-        follow_redirects=False
     )
 
     assert response.status_code == 409, f"Expected 409 Conflict, got {response.status_code}. Response: {response.text}" # Conflict - ActiveInvitationExistsError
@@ -421,7 +417,6 @@ def test_create_invitation_role_not_found(auth_client, inviter_user: User, test_
             "role_id": str(non_existent_role_id),
             "organization_id": str(test_organization.id)
         },
-        follow_redirects=False
     )
 
     # Depending on implementation, this might be 404 (Role Not Found) or 400 (Invalid Role for Org)
@@ -448,7 +443,6 @@ def test_create_invitation_role_wrong_organization(auth_client, inviter_user: Us
             "role_id": str(other_role.id),  # Role from the wrong org
             "organization_id": str(test_organization.id) # Target the main test org
         },
-        follow_redirects=False
     )
 
     # Plan suggests 400 Bad Request
@@ -473,12 +467,10 @@ def test_create_invitation_unauthenticated(unauth_client, test_organization: Org
             "role_id": str(member_role.id),
             "organization_id": str(test_organization.id)
         },
-        follow_redirects=False # Check for redirect explicitly
     )
 
     assert response.status_code == 303, f"Expected 303 redirect to login, got {response.status_code}" # Redirect to login
-    # Optionally check that the redirect location is the login page
-    # assert "/login" in response.headers.get("location", "")
+    assert response.headers["location"] == app.url_path_for("read_login")
 
 def test_create_invitation_email_send_failure(auth_client, inviter_user: User, test_organization: Organization, session: Session, mock_resend_send: MagicMock):
     """Test that invitation creation fails and rolls back if email sending fails."""
@@ -501,7 +493,6 @@ def test_create_invitation_email_send_failure(auth_client, inviter_user: User, t
             "role_id": str(member_role_id),
             "organization_id": str(test_organization.id)
         },
-        follow_redirects=False
     )
 
     assert response.status_code == 500, f"Expected 500 Internal Server Error, got {response.status_code}. Response: {response.text}"
@@ -523,7 +514,6 @@ def test_organization_page_shows_active_invitations(auth_client_owner, test_orga
     assert test_organization.id is not None
     response = auth_client_owner.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     assert response.status_code == 200
@@ -542,7 +532,6 @@ def test_organization_page_invite_form_visibility(auth_client_owner, auth_client
     # Owner should see invitation form (has INVITE_USER permission via Owner role -> permission fixture)
     owner_response = auth_client_owner.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
     assert owner_response.status_code == 200
     assert '<form' in owner_response.text
@@ -553,7 +542,6 @@ def test_organization_page_invite_form_visibility(auth_client_owner, auth_client
     # Admin should also see invitation form (has INVITE_USER permission via Admin role -> permission fixture)
     admin_response = auth_client_admin.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
     assert admin_response.status_code == 200
     assert '<form' in admin_response.text
@@ -562,7 +550,6 @@ def test_organization_page_invite_form_visibility(auth_client_owner, auth_client
     # Regular member should not see invitation form (lacks INVITE_USER permission)
     member_response = auth_client_member.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
     assert member_response.status_code == 200
 

--- a/tests/routers/core/test_invitation_acceptance.py
+++ b/tests/routers/core/test_invitation_acceptance.py
@@ -18,7 +18,6 @@ def test_accept_invitation_new_user_get_redirects_to_register(
     response = unauth_client.get(
         app.url_path_for("accept_invitation"),
         params={"token": test_invitation.token},
-        follow_redirects=False
     )
     assert response.status_code == 303
     redirect_location = response.headers["location"]
@@ -46,7 +45,6 @@ def test_accept_invitation_new_user_post_registers_and_accepts(
     response = unauth_client.post(
         app.url_path_for("register"),
         data=register_data,
-        follow_redirects=False
     )
 
     assert response.status_code == 303
@@ -89,7 +87,6 @@ def test_accept_invitation_existing_user_logged_out_get_redirects_to_login(
     response = unauth_client.get(
         app.url_path_for("accept_invitation"),
         params={"token": test_invitation.token},
-        follow_redirects=False
     )
     assert response.status_code == 303
     redirect_location = response.headers["location"]
@@ -116,7 +113,6 @@ def test_accept_invitation_existing_user_post_logs_in_and_accepts(
     response = unauth_client.post(
         app.url_path_for("login"),
         data=login_data,
-        follow_redirects=False
     )
 
     assert response.status_code == 303
@@ -151,7 +147,6 @@ def test_accept_invitation_logged_in_correct_user_get_accepts_and_redirects(
     response = auth_client_invitee.get(
         app.url_path_for("accept_invitation"),
         params={"token": test_invitation.token},
-        follow_redirects=False
     )
 
     assert response.status_code == 303
@@ -193,7 +188,6 @@ def test_accept_invitation_get_invalid_token_fails(
     response = unauth_client.get(
         app.url_path_for("accept_invitation"),
         params={"token": token_value},
-        follow_redirects=False
     )
     assert response.status_code == 404 # InvalidInvitationTokenError maps to 404
 
@@ -229,7 +223,6 @@ def test_accept_invitation_register_post_invalid_token_fails(
     response = unauth_client.post(
         app.url_path_for("register"),
         data=register_data,
-        follow_redirects=False
     )
     assert response.status_code == 404 # InvalidInvitationTokenError
 
@@ -261,7 +254,6 @@ def test_accept_invitation_login_post_invalid_token_fails(
     response = unauth_client.post(
         app.url_path_for("login"),
         data=login_data,
-        follow_redirects=False
     )
     assert response.status_code == 404 # InvalidInvitationTokenError
 
@@ -281,7 +273,6 @@ def test_accept_invitation_register_email_mismatch_fails(
     response = unauth_client.post(
         app.url_path_for("register"),
         data=register_data,
-        follow_redirects=False
     )
     assert response.status_code == 403 # InvitationEmailMismatchError
 
@@ -300,7 +291,6 @@ def test_accept_invitation_login_email_mismatch_fails(
     response = unauth_client.post(
         app.url_path_for("login"),
         data=login_data,
-        follow_redirects=False
     )
     assert response.status_code == 403 # InvitationEmailMismatchError
 
@@ -315,7 +305,6 @@ def test_accept_invitation_logged_in_wrong_user_get_redirects_to_login(
     response = auth_client_non_member.get(
         app.url_path_for("accept_invitation"),
         params={"token": test_invitation.token},
-        follow_redirects=False
     )
     assert response.status_code == 303
     redirect_location = response.headers["location"]

--- a/tests/routers/core/test_organization.py
+++ b/tests/routers/core/test_organization.py
@@ -11,7 +11,6 @@ def test_create_organization_success(auth_client, session, test_user):
     response = auth_client.post(
         app.url_path_for("create_organization"),
         data={"name": "New Test Organization"},
-        follow_redirects=False
     )
 
     # Check response
@@ -84,7 +83,6 @@ def test_create_organization_duplicate_name(auth_client, session, test_organizat
     response = auth_client.post(
         app.url_path_for("create_organization"),
         data={"name": test_organization.name},
-        follow_redirects=False
     )
     
     # Verify the response is a 400 Bad Request
@@ -107,10 +105,10 @@ def test_create_organization_unauthenticated(unauth_client):
     response = unauth_client.post(
         app.url_path_for("create_organization"),
         data={"name": "Unauthorized Org"},
-        follow_redirects=False
     )
-    
+
     assert response.status_code == 303  # Unauthorized
+    assert response.headers["location"] == app.url_path_for("read_login")
 
 def test_update_organization_success(
         auth_client: TestClient, session: Session, test_organization: Organization, test_user: User
@@ -152,7 +150,6 @@ def test_update_organization_success(
     response = auth_client.post(
         app.url_path_for("update_organization", org_id=test_organization.id),
         data={"id": str(test_organization.id), "name": new_name},
-        follow_redirects=False
     )
 
     assert response.status_code == 303  # Redirect status code
@@ -181,7 +178,6 @@ def test_update_organization_unauthorized(auth_client, session, test_organizatio
             "id": test_organization.id,
             "name": "Unauthorized Update"
         },
-        follow_redirects=False
     )
 
     assert response.status_code == 403
@@ -227,7 +223,6 @@ def test_update_organization_duplicate_name(auth_client, session, test_organizat
             "id": test_organization.id,
             "name": "Existing Org"
         },
-        follow_redirects=False
     )
 
     assert response.status_code == 400
@@ -286,10 +281,10 @@ def test_update_organization_unauthenticated(unauth_client, test_organization):
             "id": test_organization.id,
             "name": "Unauthorized Update"
         },
-        follow_redirects=False
     )
 
     assert response.status_code == 303  # Redirect to login
+    assert response.headers["location"] == app.url_path_for("read_login")
 
 def test_delete_organization_success(auth_client, session, test_organization, test_user):
     """Test successful organization deletion"""
@@ -327,7 +322,6 @@ def test_delete_organization_success(auth_client, session, test_organization, te
 
     response = auth_client.post(
         app.url_path_for("delete_organization", org_id=org_id),
-        follow_redirects=False
     )
 
     assert response.status_code == 303  # Redirect status code
@@ -347,7 +341,6 @@ def test_delete_organization_unauthorized(auth_client_member, session, test_orga
     # Use auth_client_member, who belongs to the org but has no delete permission
     response = auth_client_member.post(
         app.url_path_for("delete_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     assert response.status_code == 403
@@ -361,7 +354,6 @@ def test_delete_organization_not_member(auth_client_non_member, session, test_or
     """Test organization deletion by non-member"""
     response = auth_client_non_member.post(
         app.url_path_for("delete_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     assert response.status_code == 403
@@ -375,10 +367,10 @@ def test_delete_organization_unauthenticated(unauth_client, test_organization):
     """Test organization deletion without authentication"""
     response = unauth_client.post(
         app.url_path_for("delete_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     assert response.status_code == 303  # Redirect to login
+    assert response.headers["location"] == app.url_path_for("read_login")
 
 def test_delete_organization_cascade(auth_client, session, test_organization, test_user):
     """Test that deleting organization cascades to roles"""
@@ -425,10 +417,10 @@ def test_delete_organization_cascade(auth_client, session, test_organization, te
 
     response = auth_client.post(
         app.url_path_for("delete_organization", org_id=org_id),
-        follow_redirects=False
     )
 
     assert response.status_code == 303
+    assert app.url_path_for("read_profile") in response.headers["location"]
 
     # Expire all objects in the session to force a refresh from the database
     session.expire_all()
@@ -446,7 +438,6 @@ def test_read_organization_as_owner(auth_client_owner, test_organization):
     """Test accessing organization page as an owner"""
     response = auth_client_owner.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     assert response.status_code == 200
@@ -460,7 +451,6 @@ def test_read_organization_as_admin(auth_client_admin, test_organization):
     """Test accessing organization page as an admin"""
     response = auth_client_admin.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     assert response.status_code == 200
@@ -474,7 +464,6 @@ def test_read_organization_as_member(auth_client_member, test_organization):
     """Test accessing organization page as a regular member"""
     response = auth_client_member.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     assert response.status_code == 200
@@ -488,7 +477,6 @@ def test_read_organization_as_non_member(auth_client_non_member, test_organizati
     """Test accessing organization page as a non-member"""
     response = auth_client_non_member.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     # Non-members should get an error when accessing the organization
@@ -500,7 +488,6 @@ def test_organization_page_displays_members_correctly(auth_client_owner, org_adm
     """Test that members and their roles are displayed correctly"""
     response = auth_client_owner.get(
         app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
     )
 
     assert response.status_code == 200
@@ -553,7 +540,6 @@ def test_empty_organization_displays_no_members_message(auth_client_owner, sessi
 
     response = auth_client_owner.get(
         app.url_path_for("read_organization", org_id=empty_org.id),
-        follow_redirects=False
     )
 
     # This will fail before implementation but should pass after
@@ -572,7 +558,6 @@ def test_invite_user_success(auth_client_owner, session, test_organization, non_
     response = auth_client_owner.post(
         app.url_path_for("invite_member", org_id=test_organization.id),
         data={"email": non_member_user.account.email},
-        follow_redirects=False
     )
 
     # Should redirect back to organization page

--- a/tests/routers/core/test_role.py
+++ b/tests/routers/core/test_role.py
@@ -40,8 +40,7 @@ def test_create_role_success(auth_client, admin_user, test_organization, session
             "name": "Test Role",
             "organization_id": test_organization.id,
             "permissions": [ValidPermissions.EDIT_ROLE.value]
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 303
@@ -69,8 +68,7 @@ def test_create_role_unauthorized(auth_client, test_user, test_organization):
             "name": "Test Role",
             "organization_id": test_organization.id,
             "permissions": [ValidPermissions.EDIT_ROLE.value]
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 403
@@ -93,8 +91,7 @@ def test_create_duplicate_role(auth_client, admin_user, test_organization, sessi
             "name": "Existing Role",
             "organization_id": test_organization.id,
             "permissions": [ValidPermissions.EDIT_ROLE.value]
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 400
@@ -108,11 +105,11 @@ def test_create_role_unauthenticated(unauth_client, test_organization):
             "name": "Test Role",
             "organization_id": test_organization.id,
             "permissions": [ValidPermissions.EDIT_ROLE.value]
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 303
+    assert response.headers["location"] == app.url_path_for("read_login")
 
 
 @pytest.fixture
@@ -176,8 +173,7 @@ def test_update_role_success(auth_client, editor_user, test_organization, sessio
             "name": "New Role Name",
             "organization_id": test_organization.id,
             "permissions": [ValidPermissions.EDIT_ROLE.value]  # remove CREATE_ROLE, add EDIT_ROLE
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 303
@@ -320,10 +316,10 @@ def test_update_role_unauthenticated(unauth_client, test_organization, session: 
             "name": "Should Not Succeed",
             "organization_id": test_organization.id,
             "permissions": [ValidPermissions.EDIT_ROLE.value]
-        },
-        follow_redirects=False
+        }
     )
     assert response.status_code == 303
+    assert response.headers["location"] == app.url_path_for("read_login")
 
 
 @pytest.fixture
@@ -369,12 +365,12 @@ def test_delete_role_success(auth_client, delete_role_user, test_organization, s
         data={
             "id": role_id,
             "organization_id": test_organization.id
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 303
-    
+    assert app.url_path_for("read_organization", org_id=test_organization.id) in response.headers["location"]
+
     # Expire all objects in the session to force a refresh from the database
     session.expire_all()
 
@@ -400,8 +396,7 @@ def test_delete_role_unauthorized(auth_client, test_user, test_organization, ses
         data={
             "id": role.id,
             "organization_id": test_organization.id
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 403
@@ -414,8 +409,7 @@ def test_delete_nonexistent_role(auth_client, delete_role_user, test_organizatio
         data={
             "id": 99999,  # Non-existent role ID
             "organization_id": test_organization.id
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 404
@@ -440,8 +434,7 @@ def test_delete_role_with_users(auth_client, delete_role_user, test_organization
         data={
             "id": role_with_users.id,
             "organization_id": test_organization.id
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 400
@@ -462,11 +455,11 @@ def test_delete_role_unauthenticated(unauth_client, test_organization, session: 
         data={
             "id": role.id,
             "organization_id": test_organization.id
-        },
-        follow_redirects=False
+        }
     )
 
     assert response.status_code == 303  # Redirects to login page
+    assert response.headers["location"] == app.url_path_for("read_login")
 
 
 # --- Organization Page Role Tests ---
@@ -475,26 +468,23 @@ def test_organization_page_role_creation_access(auth_client_owner, auth_client_a
     """Test that role creation UI elements are only shown to users with CREATE_ROLE permission"""
     # Owner should see role creation
     owner_response = auth_client_owner.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert owner_response.status_code == 200
     # Check for the button's modal trigger specifically
     assert 'data-bs-target="#createRoleModal"' in owner_response.text
-    
+
     # Admin should see role creation
     admin_response = auth_client_admin.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert admin_response.status_code == 200
     # Check for the button's modal trigger specifically
     assert 'data-bs-target="#createRoleModal"' in admin_response.text
-    
+
     # Member should not see role creation
     member_response = auth_client_member.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert member_response.status_code == 200
     # Check that the button's modal trigger is NOT present
@@ -514,24 +504,21 @@ def test_organization_page_role_edit_access(auth_client_owner, auth_client_admin
 
     # Owner should see the edit button for the custom role
     owner_response = auth_client_owner.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert owner_response.status_code == 200
     assert re.search(edit_button_pattern, owner_response.text) is not None, "Owner should see edit button for custom role"
-    
+
     # Admin should see the edit button for the custom role
     admin_response = auth_client_admin.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert admin_response.status_code == 200
     assert re.search(edit_button_pattern, admin_response.text) is not None, "Admin should see edit button for custom role"
 
     # Member should not see *any* edit role button
     member_response = auth_client_member.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert member_response.status_code == 200
     # Use a general pattern to ensure no edit buttons are present for the member
@@ -551,8 +538,7 @@ def test_organization_page_role_delete_access(auth_client_owner, auth_client_adm
 
     # Owner should see the delete role form action because a custom role exists and they have permission
     owner_response = auth_client_owner.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert owner_response.status_code == 200
     delete_form_pattern = (
@@ -566,16 +552,14 @@ def test_organization_page_role_delete_access(auth_client_owner, auth_client_adm
 
     # Admin should see the delete role form action
     admin_response = auth_client_admin.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert admin_response.status_code == 200
     assert re.search(delete_form_pattern, admin_response.text, re.DOTALL) is not None
 
     # Member should *not* see the delete role form action
     member_response = auth_client_member.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert member_response.status_code == 200
     assert re.search(delete_form_pattern, member_response.text, re.DOTALL) is None
@@ -609,8 +593,7 @@ def test_organization_page_always_shows_default_roles(auth_client_member, test_o
     assert len(custom_roles) == 0, "Test setup failed: Custom roles exist unexpectedly."
 
     response = auth_client_member.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert response.status_code == 200
 
@@ -627,8 +610,7 @@ def test_organization_page_no_edit_for_default_roles(auth_client_owner, test_org
     (Owner, Administrator, Member), even for the owner.
     """
     response = auth_client_owner.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert response.status_code == 200
 
@@ -657,8 +639,7 @@ def test_organization_page_no_delete_for_default_roles(auth_client_owner, test_o
     This re-verifies and centralizes checks from test_organization_page_role_delete_access.
     """
     response = auth_client_owner.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert response.status_code == 200
 
@@ -701,8 +682,7 @@ def test_update_default_role_api_forbidden(auth_client_owner, test_organization,
             "name": f"Attempt to Change {default_role_name} Role",
             "organization_id": test_organization.id,
             "permissions": [ValidPermissions.EDIT_ROLE.value] # Arbitrary permission
-        },
-        follow_redirects=False # We expect a direct 403, not a redirect
+        }
     )
 
     assert response.status_code == 403 # Expecting Forbidden
@@ -733,8 +713,7 @@ def test_delete_default_role_api_forbidden(auth_client_owner, test_organization,
         data={
             "id": default_role_id, # Use dynamically fetched ID
             "organization_id": test_organization.id
-        },
-        follow_redirects=False # We expect a direct 403, not a redirect
+        }
     )
 
     assert response.status_code == 403 # Expecting Forbidden
@@ -743,12 +722,11 @@ def test_delete_default_role_api_forbidden(auth_client_owner, test_organization,
 def test_create_role_form_modal(auth_client_owner, test_organization):
     """Test that the create role modal form contains all required elements"""
     response = auth_client_owner.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
-    
+
     assert response.status_code == 200
-    
+
     # Check for modal elements
     assert 'id="createRoleModal"' in response.text
     assert f'action="http://testserver{app.url_path_for('create_role')}"' in response.text
@@ -790,8 +768,7 @@ def test_edit_role_form_modal(auth_client_owner, session, test_organization):
     assert ValidPermissions.DELETE_ROLE not in role_permission_names, "DELETE_ROLE should not be in permissions before test"
 
     response = auth_client_owner.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
     assert response.status_code == 200
 
@@ -835,12 +812,11 @@ def test_delete_role_form(auth_client_owner, session, test_organization):
     session.refresh(test_role)
     
     response = auth_client_owner.get(
-        app.url_path_for("read_organization", org_id=test_organization.id),
-        follow_redirects=False
+        app.url_path_for("read_organization", org_id=test_organization.id)
     )
-    
+
     assert response.status_code == 200
-    
+
     # Check for delete form elements
     assert f'action="http://testserver{app.url_path_for('delete_role')}"' in response.text
     assert 'method="POST"' in response.text or 'method="post"' in response.text

--- a/tests/routers/core/test_user.py
+++ b/tests/routers/core/test_user.py
@@ -16,7 +16,7 @@ MOCK_CONTENT_TYPE = "image/png"
 def test_read_profile_unauthorized(unauth_client: TestClient):
     """Test that unauthorized users cannot view profile"""
     response = unauth_client.get(app.url_path_for(
-        "read_profile"), follow_redirects=False)
+        "read_profile"))
     assert response.status_code == 303  # Redirect to login
     assert response.headers["location"] == app.url_path_for("read_login")
 
@@ -51,7 +51,6 @@ def test_update_profile_unauthorized(unauth_client: TestClient):
         files={
             "avatar_file": ("test_avatar.jpg", b"fake image data", "image/jpeg")
         },
-        follow_redirects=False
     )
     assert response.status_code == 303  # Redirect to login
     assert response.headers["location"] == app.url_path_for("read_login")
@@ -75,7 +74,6 @@ def test_update_profile_authorized(
         files={
             "avatar_file": ("test_avatar.jpg", b"fake image data", "image/jpeg")
         },
-        follow_redirects=False
     )
     assert response.status_code == 303
     assert response.headers["location"] == app.url_path_for("read_profile")
@@ -98,7 +96,6 @@ def test_update_profile_without_avatar(auth_client: TestClient, test_user: User,
         data={
             "name": "Updated Name"
         },
-        follow_redirects=False
     )
     assert response.status_code == 303
     assert response.headers["location"] == app.url_path_for("read_profile")
@@ -113,7 +110,6 @@ def test_delete_account_unauthorized(unauth_client: TestClient):
     response: Response = unauth_client.post(
         app.url_path_for("delete_account"),
         data={"confirm_delete_password": "Test123!@#"},
-        follow_redirects=False
     )
     assert response.status_code == 303  # Redirect to login
     assert response.headers["location"] == app.url_path_for("read_login")
@@ -127,7 +123,6 @@ def test_delete_account_wrong_password(auth_client: TestClient, test_user: User)
             "email": test_user.account.email if test_user.account else "",
             "password": "WrongPassword123!"
         },
-        follow_redirects=False
     )
     assert response.status_code == 422
     assert "Password is incorrect" in response.text.strip()
@@ -146,7 +141,6 @@ def test_delete_account_success(auth_client: TestClient, test_user: User, sessio
             "email": test_user.account.email if test_user.account else "",
             "password": "Test123!@#"
         },
-        follow_redirects=False
     )
     assert response.status_code == 303
     assert response.headers["location"] == app.url_path_for("logout")
@@ -192,7 +186,6 @@ def test_get_avatar_unauthorized(unauth_client: TestClient):
     """Test getting avatar for non-existent user"""
     response = unauth_client.get(
         app.url_path_for("get_avatar"),
-        follow_redirects=False
     )
     assert response.status_code == 303
     assert response.headers["location"] == app.url_path_for("read_login")

--- a/tests/test_htmx.py
+++ b/tests/test_htmx.py
@@ -150,9 +150,9 @@ def test_create_role_non_htmx_redirects(auth_client_owner, test_organization):
             "name": "Viewer2",
             "organization_id": str(test_organization.id),
         },
-        follow_redirects=False,
     )
     assert response.status_code == 303
+    assert response.headers["location"] == f"/organizations/{test_organization.id}"
 
 
 def test_delete_role_htmx_returns_partial(auth_client_owner, test_organization, session):
@@ -248,9 +248,9 @@ def test_update_profile_non_htmx_redirects(auth_client):
     response = auth_client.post(
         "/user/update",
         data={"name": "Updated Name"},
-        follow_redirects=False,
     )
     assert response.status_code == 303
+    assert response.headers["location"] == "/user/profile"
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +380,6 @@ def test_forgot_password_rate_limit_htmx_returns_toast(unauth_client):
             "/account/forgot_password",
             data={"email": "user@example.com"},
             headers=htmx_headers(),
-            follow_redirects=False,
         )
 
     response = unauth_client.post(


### PR DESCRIPTION
## Summary
- Set `follow_redirects=False` on all `TestClient` instances in `conftest.py` instead of passing it per API call
- Removed ~90 redundant `follow_redirects=False` arguments from individual test calls
- Added redirect location assertions (`response.headers["location"]`) to all tests that check 3xx status codes but previously didn't verify the redirect target
- Fixed `InsecureKeyLengthWarning` by using a test `SECRET_KEY` longer than 32 bytes

Closes #101

## Test plan
- [x] All 348 tests pass with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)