### PR TITLE
Consolidate profile dropdown with hamburger menu on mobile

### DIFF
--- a/templates/base/partials/header.html
+++ b/templates/base/partials/header.html
@@ -17,10 +17,22 @@
 
         <div class="collapse navbar-collapse" id="navbarContent">
             {% include 'base/partials/nav.html' %}
-            
-            <!-- User Profile Dropdown -->
-            <ul class="navbar-nav ms-auto mb-lg-0">
-                {% if user %}
+
+            {% if user %}
+            <!-- Mobile-only nav items: Profile and Logout as plain links -->
+            <ul class="navbar-nav d-lg-none">
+                <li class="nav-item" id="mobile-nav-profile">
+                    <a class="nav-link" href="{{ url_for('read_profile') }}">Profile</a>
+                </li>
+                <li class="nav-item" id="mobile-nav-logout">
+                    <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+                </li>
+            </ul>
+            {% endif %}
+
+            {% if user %}
+            <!-- Desktop-only: User Profile Dropdown with avatar -->
+            <ul class="navbar-nav ms-auto mb-lg-0 d-none d-lg-flex">
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <button class="profile-button btn p-0 border-0 bg-transparent">
@@ -37,15 +49,18 @@
                         <li><a class="dropdown-item" href="{{ url_for('logout') }}">Logout</a></li>
                     </ul>
                 </li>
-                {% else %}
+            </ul>
+            {% else %}
+            <!-- Login/Register links (all screen sizes) -->
+            <ul class="navbar-nav ms-auto mb-lg-0">
                 <li class="nav-item">
                     <a class="nav-link" href="{{ url_for('read_login') }}">Login</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="{{ url_for('read_register') }}">Register</a>
                 </li>
-                {% endif %}
             </ul>
+            {% endif %}
         </div>
     </div>
 </header>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -216,3 +216,39 @@ def test_delete_organization_form_has_hx_post():
 def test_nav_has_hx_boost():
     content = Path("templates/base/partials/header.html").read_text()
     assert 'hx-boost="true"' in content
+
+
+class TestMobileNavConsolidation:
+    """Tests for consolidated mobile navigation (issue #80).
+
+    On mobile, profile dropdown items should appear as regular nav links
+    in the hamburger menu, and the dropdown should be hidden.
+    """
+
+    def setup_method(self):
+        self.content = Path("templates/base/partials/header.html").read_text()
+
+    def test_mobile_profile_link_exists(self):
+        """Mobile-only Profile link should exist with d-lg-none visibility."""
+        assert 'd-lg-none' in self.content
+        # There should be a mobile-only nav item linking to profile
+        assert 'mobile-nav-profile' in self.content
+
+    def test_mobile_logout_link_exists(self):
+        """Mobile-only Logout link should exist with d-lg-none visibility."""
+        assert 'mobile-nav-logout' in self.content
+
+    def test_desktop_dropdown_hidden_on_mobile(self):
+        """The profile dropdown should be hidden on mobile (d-none d-lg-flex)."""
+        # The dropdown container should have classes to hide on mobile
+        assert 'd-lg-flex' in self.content
+        # Verify the dropdown is inside a container hidden on mobile
+        assert 'd-none d-lg-flex' in self.content
+
+    def test_mobile_nav_items_inside_collapsible(self):
+        """Mobile nav items should be inside the navbarContent collapsible."""
+        # Find the collapsible section and verify mobile nav items are inside it
+        collapse_start = self.content.index('id="navbarContent"')
+        collapse_section = self.content[collapse_start:]
+        assert 'mobile-nav-profile' in collapse_section
+        assert 'mobile-nav-logout' in collapse_section


### PR DESCRIPTION
  Template changes (templates/base/partials/header.html):
  1. Added a mobile-only <ul class="navbar-nav d-lg-none"> with plain Profile and Logout links inside the collapsible  
  section (only for authenticated users)
  2. Wrapped the desktop avatar dropdown in d-none d-lg-flex so it's hidden on mobile
  3. Kept Login/Register links visible on all screen sizes (not wrapped in d-none)

  The result: on mobile, authenticated users see Profile and Logout as regular nav items in the hamburger menu (no
  dropdown, no avatar thumbnail). On desktop, the avatar dropdown works as before.
