### PR TITLE
Replace custom JS toast system with HTMX-native patterns

### DIFF
--- a/.claude/projects/-home-chriscarrollsmith-Documents-Software-Websites-fastapi-jinja2-postgres-webapp/memory/MEMORY.md
+++ b/.claude/projects/-home-chriscarrollsmith-Documents-Software-Websites-fastapi-jinja2-postgres-webapp/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory Index
+
+- [feedback_red_green_testing.md](feedback_red_green_testing.md) — Always write a failing test before fixing a bug

--- a/.claude/projects/-home-chriscarrollsmith-Documents-Software-Websites-fastapi-jinja2-postgres-webapp/memory/feedback_red_green_testing.md
+++ b/.claude/projects/-home-chriscarrollsmith-Documents-Software-Websites-fastapi-jinja2-postgres-webapp/memory/feedback_red_green_testing.md
@@ -1,0 +1,11 @@
+---
+name: Red-green testing discipline
+description: Always write a failing test (red phase) before applying a bug fix so the fix is validated
+type: feedback
+---
+
+Always write a failing test that surfaces the bug before applying the fix. Running tests after a fix without a red-phase test doesn't prove anything.
+
+**Why:** The user expects disciplined red-green-refactor workflow. A test that only exists after the fix could be passing for the wrong reason.
+
+**How to apply:** When fixing a bug, first add or update a test that fails with the current code, confirm it fails, then apply the fix and confirm it passes.

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from utils.core.dependencies import (
     require_unauthenticated_client
 )
 from utils.core.auth import COOKIE_SECURE
-from utils.core.htmx import is_htmx_request, toast_response
+from utils.core.htmx import is_htmx_request, toast_response, get_flash_cookie, FLASH_COOKIE_NAME
 from exceptions.http_exceptions import (
     AlreadyAuthenticatedError,
     AuthenticationError,
@@ -45,6 +45,22 @@ app: FastAPI = FastAPI(lifespan=lifespan)
 # Mount static files (e.g., CSS, JS) and initialize Jinja2 templates
 app.mount("/static", StaticFiles(directory="static"), name="static")
 templates = Jinja2Templates(directory="templates")
+
+
+# --- Flash cookie middleware ---
+# Reads the flash cookie into request.state so templates can render it
+# server-side, then clears the cookie on the response.
+
+
+@app.middleware("http")
+async def flash_cookie_middleware(request: Request, call_next):
+    flash = get_flash_cookie(request)
+    request.state.flash = flash
+    response = await call_next(request)
+    if flash:
+        response.delete_cookie(FLASH_COOKIE_NAME, path="/")
+    return response
+
 
 
 # --- Include Routers ---

--- a/routers/core/user.py
+++ b/routers/core/user.py
@@ -116,6 +116,7 @@ async def update_profile(
 
     # Handle avatar update
     if avatar_changed:
+        assert avatar_file is not None
         avatar_data = await avatar_file.read()
         avatar_content_type = avatar_file.content_type
 

--- a/routers/core/user.py
+++ b/routers/core/user.py
@@ -141,17 +141,21 @@ async def update_profile(
     session.refresh(user)
 
     if is_htmx_request(request):
-        if avatar_changed:
-            # Avatar affects the navbar, which is outside the swap target.
-            # Tell HTMX to do a full page refresh so everything updates.
-            response = Response(status_code=200)
-            response.headers["HX-Refresh"] = "true"
-            return response
         response = templates.TemplateResponse(
             request,
             "users/partials/profile_display.html",
             {"user": user},
         )
+        if avatar_changed:
+            # Avatar also appears in the navbar — append an OOB swap for it.
+            navbar_html = bytes(templates.TemplateResponse(
+                request,
+                "base/partials/navbar_avatar_oob.html",
+                {"user": user},
+            ).body).decode()
+            original = bytes(response.body).decode()
+            response.body = (original + navbar_html).encode()
+            response.headers["content-length"] = str(len(response.body))
         return append_toast(response, request, templates, "Profile updated successfully.")
     return RedirectResponse(url=router.url_path_for("read_profile"), status_code=303)
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,58 +3,19 @@
 // re-processed during htmx hx-boost body swaps, which means the event
 // listeners registered here persist across page navigations.
 
-function showToast(message, level) {
-    level = level || 'success';
-    var container = document.getElementById('toast-container');
-    var wrapper = document.createElement('div');
-    wrapper.className = 'toast align-items-center text-bg-' + level + ' border-0 show';
-    wrapper.setAttribute('role', 'alert');
-    wrapper.setAttribute('aria-atomic', 'true');
-    wrapper.innerHTML =
-        '<div class="d-flex">' +
-            '<div class="toast-body">' + message + '</div>' +
-            '<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>' +
-        '</div>';
-    container.appendChild(wrapper);
-    setTimeout(function() { wrapper.remove(); }, 5000);
-}
-
-// For HTMX error responses, extract and apply OOB swaps (toasts) without
-// touching the main target. We parse the response HTML, find elements with
-// hx-swap-oob, and swap them in manually via htmx.process().
-document.body.addEventListener('htmx:beforeSwap', function(evt) {
-    if (evt.detail.xhr.status >= 400) {
-        evt.detail.shouldSwap = false;
-        evt.detail.isError = false;
-        var responseText = evt.detail.xhr.responseText;
-        if (responseText) {
-            var doc = new DOMParser().parseFromString(responseText, 'text/html');
-            var oobElements = doc.querySelectorAll('[hx-swap-oob]');
-            oobElements.forEach(function(el) {
-                var targetId = el.getAttribute('id');
-                if (targetId) {
-                    var existing = document.getElementById(targetId);
-                    if (existing) {
-                        existing.replaceWith(el);
-                        htmx.process(el);
-                    }
-                }
-            });
-        }
+// Configure HTMX to process response bodies on error status codes so that
+// OOB-swapped toasts are applied.  swapOverride:'none' ensures the main
+// target is left untouched while OOB elements are still processed.
+document.body.addEventListener('htmx:configRequest', function() {
+    if (!htmx.config.responseHandling.find(function(r) { return r.code === '400'; })) {
+        htmx.config.responseHandling = [
+            { code: '204', swap: false },
+            { code: '[23]..', swap: true },
+            { code: '[45]..', swap: true, error: false, swapOverride: 'none' },
+        ];
     }
-});
+}, { once: true });
 
-// Read flash cookie on page load
-(function() {
-    var raw = document.cookie.split('; ').find(function(c) { return c.startsWith('flash_message='); });
-    if (!raw) return;
-    var value = decodeURIComponent(raw.split('=').slice(1).join('='));
-    document.cookie = 'flash_message=; Max-Age=0; path=/';
-    try {
-        var flash = JSON.parse(value);
-        if (flash && flash.message) showToast(flash.message, flash.level);
-    } catch(e) {}
-})();
 
 // Global handler: when a server response includes HX-Trigger: modalDismiss,
 // clean up any Bootstrap modal backdrop left behind by OOB swaps that

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,13 +21,26 @@
          order and waits for DOM parsing to complete. -->
     <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/htmx-ext-remove-me@2.0.0/remove-me.js"></script>
     <script defer src="{{ url_for('static', path='js/app.js') }}"></script>
     {% block extra_head %}{% endblock %}
 </head>
 <body class="min-vh-100 d-flex flex-column">
     <div id="toast-container"
          class="toast-container position-fixed bottom-0 end-0 p-3"
+         hx-ext="remove-me"
          aria-live="polite">
+      {% set flash = request.state.flash %}
+      {% if flash %}
+      <div class="toast align-items-center text-bg-{{ flash.level|default('success') }} border-0 show"
+           role="alert" aria-atomic="true" remove-me="5s">
+        <div class="d-flex">
+          <div class="toast-body">{{ flash.message }}</div>
+          <button type="button" class="btn-close btn-close-white me-2 m-auto"
+                  data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+      </div>
+      {% endif %}
     </div>
 
     <header>

--- a/templates/base/partials/header.html
+++ b/templates/base/partials/header.html
@@ -1,5 +1,4 @@
 {% from 'base/macros/logo.html' import render_logo %}
-{% from 'base/macros/silhouette.html' import render_silhouette %}
 
 
 <header class="navbar navbar-expand-lg navbar-light bg-light" hx-boost="true">
@@ -35,13 +34,7 @@
             <ul class="navbar-nav ms-auto mb-lg-0 d-none d-lg-flex">
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        <button class="profile-button btn p-0 border-0 bg-transparent">
-                            {% if user.avatar %}
-                                <img src="{{ url_for('get_avatar') }}?v={{ range(1000000)|random }}" alt="User Avatar" class="d-inline-block align-top" width="30" height="30" style="border-radius: 50%;">
-                            {% else %}
-                                {{ render_silhouette() }}
-                            {% endif %}
-                        </button>
+                        {% include 'base/partials/navbar_avatar.html' %}
                     </a>
                     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                         <li><a class="dropdown-item" href="{{ url_for('read_profile') }}">Profile</a></li>

--- a/templates/base/partials/navbar_avatar.html
+++ b/templates/base/partials/navbar_avatar.html
@@ -1,0 +1,9 @@
+{# Navbar avatar button — swappable via OOB when avatar changes. #}
+{% from 'base/macros/silhouette.html' import render_silhouette %}
+<button id="navbar-avatar" class="profile-button btn p-0 border-0 bg-transparent">
+    {% if user.avatar %}
+        <img src="{{ url_for('get_avatar') }}?v={{ range(1000000)|random }}" alt="User Avatar" class="d-inline-block align-top" width="30" height="30" style="border-radius: 50%;">
+    {% else %}
+        {{ render_silhouette() }}
+    {% endif %}
+</button>

--- a/templates/base/partials/navbar_avatar_oob.html
+++ b/templates/base/partials/navbar_avatar_oob.html
@@ -1,0 +1,9 @@
+{# OOB swap for the navbar avatar after avatar update. #}
+{% from 'base/macros/silhouette.html' import render_silhouette %}
+<button id="navbar-avatar" hx-swap-oob="true" class="profile-button btn p-0 border-0 bg-transparent">
+    {% if user.avatar %}
+        <img src="{{ url_for('get_avatar') }}?v={{ range(1000000)|random }}" alt="User Avatar" class="d-inline-block align-top" width="30" height="30" style="border-radius: 50%;">
+    {% else %}
+        {{ render_silhouette() }}
+    {% endif %}
+</button>

--- a/templates/base/partials/toast.html
+++ b/templates/base/partials/toast.html
@@ -2,9 +2,10 @@
 <div id="toast-container"
      class="toast-container position-fixed bottom-0 end-0 p-3"
      hx-swap-oob="true"
+     hx-ext="remove-me"
      aria-live="polite">
   <div class="toast align-items-center text-bg-{{ level|default('danger') }} border-0 show"
-       role="alert" aria-atomic="true">
+       role="alert" aria-atomic="true" remove-me="5s">
     <div class="d-flex">
       <div class="toast-body">{{ message }}</div>
       <button type="button" class="btn-close btn-close-white me-2 m-auto"

--- a/templates/users/partials/profile_form.html
+++ b/templates/users/partials/profile_form.html
@@ -37,6 +37,22 @@
     </form>
 </div>
 <script>
+    function _clientToast(message, level) {
+        var container = document.getElementById('toast-container');
+        var wrapper = document.createElement('div');
+        wrapper.className = 'toast align-items-center text-bg-' + level + ' border-0 show';
+        wrapper.setAttribute('role', 'alert');
+        wrapper.setAttribute('aria-atomic', 'true');
+        wrapper.setAttribute('remove-me', '5s');
+        wrapper.innerHTML =
+            '<div class="d-flex">' +
+                '<div class="toast-body">' + message + '</div>' +
+                '<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>' +
+            '</div>';
+        container.appendChild(wrapper);
+        htmx.process(wrapper);
+    }
+
     document.getElementById('avatar_file').addEventListener('change', function(e) {
         var file = e.target.files[0];
         if (!file) return;
@@ -48,13 +64,13 @@
 
         var fileSizeMB = file.size / (1024 * 1024);
         if (fileSizeMB > maxSizeMB) {
-            showToast('File size must be less than ' + maxSizeMB + 'MB', 'danger');
+            _clientToast('File size must be less than ' + maxSizeMB + 'MB', 'danger');
             this.value = '';
             return;
         }
 
         if (allowedFormats.indexOf(file.type) === -1) {
-            showToast('File format must be one of: ' + allowedFormats.join(', '), 'danger');
+            _clientToast('File format must be one of: ' + allowedFormats.join(', '), 'danger');
             this.value = '';
             return;
         }
@@ -65,12 +81,12 @@
         img.onload = function() {
             URL.revokeObjectURL(this.src);
             if (this.width < minDim || this.height < minDim) {
-                showToast('Image dimensions must be at least ' + minDim + 'x' + minDim + ' pixels', 'danger');
+                _clientToast('Image dimensions must be at least ' + minDim + 'x' + minDim + ' pixels', 'danger');
                 input.value = '';
                 return;
             }
             if (this.width > maxDim || this.height > maxDim) {
-                showToast('Image dimensions must not exceed ' + maxDim + 'x' + maxDim + ' pixels', 'danger');
+                _clientToast('Image dimensions must not exceed ' + maxDim + 'x' + maxDim + ' pixels', 'danger');
                 input.value = '';
                 return;
             }

--- a/tests/browser/test_toast_display.py
+++ b/tests/browser/test_toast_display.py
@@ -1,0 +1,220 @@
+"""
+Playwright regression tests for toast display behavior.
+
+Covers three toast delivery paths:
+1. HTMX success toast — OOB swap appended to a successful HTMX response
+2. HTMX error toast — toast delivered via error response (e.g. bad credentials)
+3. Flash cookie toast — cookie set on redirect, displayed on next page load
+
+Also verifies auto-dismiss (~5 s) and manual close via the X button.
+"""
+import io
+import pytest
+from PIL import Image
+from playwright.sync_api import Page, expect
+
+
+@pytest.fixture(scope="session")
+def _register_toast_user(browser, live_server: str):
+    """Register a dedicated user for toast tests."""
+    context = browser.new_context(viewport={"width": 1280, "height": 720})
+    p = context.new_page()
+    p.goto(f"{live_server}/account/register")
+    p.fill("#name", "Toast Test User")
+    p.fill("#email", "toast-tests@example.com")
+    p.fill("#password", "TestPass123!@#")
+    p.fill("#confirm_password", "TestPass123!@#")
+    p.click('button[type="submit"]')
+    p.wait_for_function(
+        "window.location.pathname.startsWith('/dashboard')", timeout=10_000
+    )
+    context.close()
+
+
+@pytest.fixture()
+def logged_in_page(browser, live_server: str, _register_toast_user):
+    """Log in and return a page on the dashboard."""
+    context = browser.new_context(viewport={"width": 1280, "height": 720})
+    p = context.new_page()
+    p.goto(f"{live_server}/account/login")
+    p.fill("#email", "toast-tests@example.com")
+    p.fill("#password", "TestPass123!@#")
+    p.click('button[type="submit"]')
+    p.wait_for_function(
+        "window.location.pathname.startsWith('/dashboard')", timeout=10_000
+    )
+    yield p
+    context.close()
+
+
+@pytest.fixture()
+def anon_page(browser, live_server: str, _register_toast_user):
+    """Return a page that is NOT logged in."""
+    context = browser.new_context(viewport={"width": 1280, "height": 720})
+    p = context.new_page()
+    p.goto(f"{live_server}/account/login")
+    p.wait_for_load_state("networkidle")
+    yield p
+    context.close()
+
+
+# --- 1. HTMX success toast (OOB swap) ---
+
+
+def test_htmx_success_toast_appears(logged_in_page: Page, live_server: str):
+    """Updating profile name via HTMX produces a success toast."""
+    page = logged_in_page
+    page.goto(f"{live_server}/user/profile")
+    page.wait_for_load_state("networkidle")
+
+    card = page.locator("#profile-card")
+    # Enter edit mode
+    card.locator("button:has-text('Edit')").click()
+    expect(card.locator('button:has-text("Save Changes")')).to_be_visible(timeout=5_000)
+
+    # Submit the form (name unchanged is fine)
+    card.locator('button[type="submit"]').click()
+
+    # A success toast should appear in the container
+    toast = page.locator("#toast-container .toast.text-bg-success")
+    expect(toast).to_be_visible(timeout=5_000)
+    expect(toast).to_contain_text("Profile updated successfully")
+
+
+def _submit_avatar(page: Page, live_server: str, tmp_path):
+    """Navigate to profile, upload an avatar, and submit. Returns the page."""
+    page.goto(f"{live_server}/user/profile")
+    page.wait_for_load_state("networkidle")
+
+    card = page.locator("#profile-card")
+    card.locator("button:has-text('Edit')").click()
+    expect(card.locator('button:has-text("Save Changes")')).to_be_visible(timeout=5_000)
+
+    # Create a valid 200x200 PNG image
+    img = Image.new("RGB", (200, 200), color="blue")
+    img_path = tmp_path / "avatar.png"
+    img.save(img_path, format="PNG")
+
+    card.locator('input[name="avatar_file"]').set_input_files(str(img_path))
+    card.locator('button[type="submit"]').click()
+    return page
+
+
+def test_avatar_update_toast_appears(logged_in_page: Page, live_server: str, tmp_path):
+    """Updating avatar should show a success toast."""
+    page = _submit_avatar(logged_in_page, live_server, tmp_path)
+
+    toast = page.locator("#toast-container .toast.text-bg-success")
+    expect(toast).to_be_visible(timeout=10_000)
+    expect(toast).to_contain_text("Profile updated successfully")
+
+
+def test_avatar_update_no_full_reload(logged_in_page: Page, live_server: str, tmp_path):
+    """Avatar update should use OOB swaps, not a full page reload."""
+    page = logged_in_page
+    page.goto(f"{live_server}/user/profile")
+    page.wait_for_load_state("networkidle")
+
+    # Mark the DOM so we can detect if the page was fully reloaded
+    page.evaluate("() => { window.__noReload = true; }")
+
+    card = page.locator("#profile-card")
+    card.locator("button:has-text('Edit')").click()
+    expect(card.locator('button:has-text("Save Changes")')).to_be_visible(timeout=5_000)
+
+    img = Image.new("RGB", (200, 200), color="red")
+    img_path = tmp_path / "avatar.png"
+    img.save(img_path, format="PNG")
+    card.locator('input[name="avatar_file"]').set_input_files(str(img_path))
+    card.locator('button[type="submit"]').click()
+
+    # Wait for profile display to swap back in
+    expect(card.locator("button:has-text('Edit')")).to_be_visible(timeout=10_000)
+
+    # The navbar avatar should also have updated (OOB swap)
+    navbar_avatar = page.locator("#navbar-avatar img")
+    expect(navbar_avatar).to_be_visible(timeout=5_000)
+
+    # DOM marker should survive — proves no full page reload happened
+    marker = page.evaluate("() => window.__noReload")
+    assert marker is True, "Page was fully reloaded instead of using OOB swaps"
+
+
+
+# --- 2. HTMX error toast (error response path) ---
+
+
+def test_htmx_error_toast_appears(anon_page: Page):
+    """Submitting bad credentials via HTMX shows a danger toast."""
+    page = anon_page
+
+    page.fill("#email", "toast-tests@example.com")
+    page.fill("#password", "WrongPassword999!")
+    page.click('button[type="submit"]')
+
+    toast = page.locator("#toast-container .toast.text-bg-danger")
+    expect(toast).to_be_visible(timeout=5_000)
+
+
+# --- 3. Flash cookie toast (redirect + cookie) ---
+
+
+def test_flash_cookie_toast_appears(anon_page: Page, live_server: str):
+    """Forgot-password flow sets a flash cookie; toast appears after redirect."""
+    page = anon_page
+
+    page.goto(f"{live_server}/account/forgot_password")
+    page.wait_for_load_state("networkidle")
+
+    page.fill("#email", "toast-tests@example.com")
+    page.click('button[type="submit"]')
+
+    # The server sets HX-Redirect + flash cookie.  After the redirect the
+    # toast should be visible on the new page.
+    toast = page.locator("#toast-container .toast")
+    expect(toast).to_be_visible(timeout=10_000)
+    expect(toast).to_contain_text("If an account exists")
+
+
+# --- 4. Auto-dismiss ---
+
+
+def test_toast_auto_dismisses(anon_page: Page, live_server: str):
+    """Flash-cookie toasts (via showToast) disappear automatically after ~5 s."""
+    page = anon_page
+
+    page.goto(f"{live_server}/account/forgot_password")
+    page.wait_for_load_state("networkidle")
+
+    page.fill("#email", "toast-tests@example.com")
+    page.click('button[type="submit"]')
+
+    toast = page.locator("#toast-container .toast")
+    expect(toast).to_be_visible(timeout=10_000)
+
+    # showToast removes the element after 5 s — wait with buffer
+    expect(toast).to_have_count(0, timeout=8_000)
+
+
+# --- 5. Manual close button ---
+
+
+def test_toast_close_button(logged_in_page: Page, live_server: str):
+    """Clicking the close button on a toast hides it."""
+    page = logged_in_page
+    page.goto(f"{live_server}/user/profile")
+    page.wait_for_load_state("networkidle")
+
+    card = page.locator("#profile-card")
+    card.locator("button:has-text('Edit')").click()
+    expect(card.locator('button:has-text("Save Changes")')).to_be_visible(timeout=5_000)
+    card.locator('button[type="submit"]').click()
+
+    toast = page.locator("#toast-container .toast")
+    expect(toast).to_be_visible(timeout=5_000)
+
+    # Click the close button — Bootstrap hides but doesn't remove from DOM
+    toast.locator('button[data-bs-dismiss="toast"]').click()
+
+    # Toast should become invisible
+    expect(toast).not_to_be_visible(timeout=2_000)

--- a/tests/browser/test_toast_display.py
+++ b/tests/browser/test_toast_display.py
@@ -8,7 +8,6 @@ Covers three toast delivery paths:
 
 Also verifies auto-dismiss (~5 s) and manual close via the X button.
 """
-import io
 import pytest
 from PIL import Image
 from playwright.sync_api import Page, expect

--- a/tests/test_htmx.py
+++ b/tests/test_htmx.py
@@ -480,9 +480,9 @@ def test_avatar_url_includes_cache_buster():
     )
 
 
-def test_avatar_upload_htmx_triggers_full_refresh(auth_client):
-    """When an avatar is uploaded, the HTMX response should include
-    HX-Refresh so the navbar avatar updates too."""
+def test_avatar_upload_htmx_returns_oob_swap(auth_client):
+    """When an avatar is uploaded, the HTMX response should include an OOB
+    swap for the navbar avatar instead of a full page refresh."""
     import io
     from PIL import Image
     buf = io.BytesIO()
@@ -495,7 +495,9 @@ def test_avatar_upload_htmx_triggers_full_refresh(auth_client):
         headers=htmx_headers(),
     )
     assert response.status_code == 200
-    assert response.headers.get("HX-Refresh") == "true"
+    assert response.headers.get("HX-Refresh") is None
+    assert 'id="navbar-avatar"' in response.text
+    assert 'hx-swap-oob="true"' in response.text
 
 
 def test_name_only_update_htmx_no_refresh(auth_client):


### PR DESCRIPTION
## Summary
- **Toast migration**: Replaced the custom `showToast()` JS function and client-side flash cookie reader with server-side rendering via `htmx-ext-remove-me` for auto-dismiss, HTMX `responseHandling` config for error-status OOB swaps, and a flash cookie middleware for full-page-load toasts.
- **Avatar update fix**: Replaced `HX-Refresh: true` on avatar upload with OOB swaps for both the profile display and navbar avatar. This eliminates the visible flicker from full page reloads and ensures the "Profile updated successfully" toast always appears (previously lost during refresh).
- **Navbar avatar partial**: Extracted the navbar avatar into a reusable partial (`navbar_avatar.html`) with an OOB variant (`navbar_avatar_oob.html`) for HTMX responses.

## Test plan
- [x] All 362 non-browser unit/integration tests pass
- [x] All 7 Playwright browser tests pass, including:
  - `test_htmx_success_toast_appears` — name-only profile update shows toast
  - `test_avatar_update_toast_appears` — avatar update shows toast
  - `test_avatar_update_no_full_reload` — avatar update uses OOB swaps, no page reload
  - `test_htmx_error_toast_appears` — error responses show toast via OOB
  - `test_flash_cookie_toast_appears` — flash cookies render server-side on load
  - `test_toast_auto_dismisses` — toasts auto-dismiss after 5s via remove-me
  - `test_toast_close_button` — manual close button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)