### PR TITLE
fix create role modal form reset

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -20,6 +20,14 @@ document.body.addEventListener('htmx:configRequest', function() {
 // Global handler: when a server response includes HX-Trigger: modalDismiss,
 // clean up any Bootstrap modal backdrop left behind by OOB swaps that
 // replaced the modal element before afterRequest could call .hide().
+document.body.addEventListener('hidden.bs.modal', function(event) {
+    var modal = event.target;
+    if (modal.id && modal.id.startsWith('create')) {
+        var form = modal.querySelector('form');
+        if (form) { form.reset(); }
+    }
+});
+
 document.body.addEventListener('modalDismiss', function() {
     document.querySelectorAll('.modal.show').forEach(function(el) {
         var modal = bootstrap.Modal.getInstance(el);


### PR DESCRIPTION
Create Role Modal used to retain information from input and after role creation. Now the modal information is reset on cancel and after role creation.

Resolves #180 