### PR TITLE
Keep propagate matrix jobs independent

### DIFF
--- a/.github/workflows/propagate.yml
+++ b/.github/workflows/propagate.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   propagate:
     strategy:
+      fail-fast: false
       matrix:
         branch: [modal, hetzner]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Disables matrix fail-fast for the propagate workflow so a conflict or fallback failure on one deployment branch does not cancel the other branch's propagation job.
- Leaves the existing GitHub App token flow in place; the app now has PR read/write permissions for fallback PR creation.

## Test plan
- Not run; workflow-only change.


Made with [Cursor](https://cursor.com)