### PR TITLE
fix: restore autocomplete regression test + simplify communication preferences JS

### DIFF
--- a/templates/partials/communication_preferences_fields.html
+++ b/templates/partials/communication_preferences_fields.html
@@ -54,22 +54,14 @@
                 return;
             }
 
-            function syncSubPreferences() {
-                if (master.checked) {
-                    subPrefs.style.display = '';
-                } else {
-                    subPrefs.style.display = 'none';
-                    updates.checked = false;
-                    marketing.checked = false;
-                }
-            }
-
             master.addEventListener('change', function () {
                 if (master.checked) {
                     subPrefs.style.display = '';
                     updates.checked = true;
                 } else {
-                    syncSubPreferences();
+                    subPrefs.style.display = 'none';
+                    updates.checked = false;
+                    marketing.checked = false;
                 }
             });
         });

--- a/tests/routers/core/test_account.py
+++ b/tests/routers/core/test_account.py
@@ -450,6 +450,9 @@ def test_register_page_shows_password_requirements(unauth_client: TestClient):
     assert 'name="comm_opt_in"' in html
     assert 'name="comm_updates"' in html
     assert 'name="comm_marketing"' in html
+
+
+def test_register_page_confirm_password_has_autocomplete(unauth_client: TestClient):
     """Issue #156: Both password fields must have autocomplete='new-password' for Chrome autofill."""
     response = unauth_client.get(app.url_path_for("read_register"))
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
Two small, related cleanups to the communication-preferences feature added in #195:

1. **Restore the confirm-password autocomplete regression test.** #195 accidentally deleted the `def` line for `test_register_page_confirm_password_has_autocomplete`, collapsing its body into `test_register_page_shows_password_requirements` and demoting its docstring to a no-op string statement. The issue #156 autocomplete check is restored as its own test. The comm-preference assertions remain in `test_register_page_shows_password_requirements`, where they correctly verify the register page renders the new fields.

2. **Drop the `syncSubPreferences` helper.** In `communication_preferences_fields.html` the helper was only ever called from the master checkbox's `change` handler (disable branch) and never on init — initial visibility is already set server-side via the Jinja `style="display: none;"` guard. Inlining it removes the indirection and the enable/disable asymmetry. Behavior is preserved exactly: enabling reveals the sub-preferences and checks `comm_updates`; disabling hides them and clears both sub-preferences.

## Test plan
- [x] `uv run pytest tests/routers/core/test_account.py` (91 passed)
- [x] `uv run pytest tests/test_templates.py` (30 passed)
- [x] Both `test_register_page_shows_password_requirements` and `test_register_page_confirm_password_has_autocomplete` are collected as separate tests
- [x] `uv run ty check .` clean