### PR TITLE
refactor: inline syncSubPreferences into master change handler

### DIFF
--- a/templates/partials/communication_preferences_fields.html
+++ b/templates/partials/communication_preferences_fields.html
@@ -54,22 +54,14 @@
                 return;
             }
 
-            function syncSubPreferences() {
-                if (master.checked) {
-                    subPrefs.style.display = '';
-                } else {
-                    subPrefs.style.display = 'none';
-                    updates.checked = false;
-                    marketing.checked = false;
-                }
-            }
-
             master.addEventListener('change', function () {
                 if (master.checked) {
                     subPrefs.style.display = '';
                     updates.checked = true;
                 } else {
-                    syncSubPreferences();
+                    subPrefs.style.display = 'none';
+                    updates.checked = false;
+                    marketing.checked = false;
                 }
             });
         });


### PR DESCRIPTION
## Summary
- The `syncSubPreferences` helper in `communication_preferences_fields.html` was only ever called from the master checkbox's `change` handler (the disable branch) and was never invoked on page load — initial sub-preference visibility is already set server-side via the Jinja `style="display: none;"` guard.
- Inlining it removes the indirection and the asymmetry between the enable and disable paths.
- Behavior is preserved exactly: enabling the master reveals the sub-preferences and checks `comm_updates`; disabling hides them and clears both `comm_updates` and `comm_marketing`.

## Test plan
- [x] `uv run pytest tests/test_templates.py` (30 passed)
- [x] `uv run ty check .` clean

Made with [Cursor](https://cursor.com)