### PR TITLE
Audit SQLModel typing and test isolation (#201)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,14 @@ from utils.core.auth import (
 )
 from main import app
 from datetime import datetime, UTC, timedelta
+from utils.core.rate_limit import clear_all_rate_limiters
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiters() -> Generator[None, None, None]:
+    clear_all_rate_limiters()
+    yield
+    clear_all_rate_limiters()
 
 
 # Define a custom exception for test setup errors

--- a/tests/routers/core/test_account.py
+++ b/tests/routers/core/test_account.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 from starlette.datastructures import URLPath
 from sqlmodel import Session, select
@@ -28,27 +27,12 @@ from utils.core.auth import (
     get_password_hash,
 )
 from utils.core.rate_limit import (
-    login_ip_limiter,
-    login_email_limiter,
-    register_ip_limiter,
-    forgot_password_ip_limiter,
     forgot_password_email_limiter,
+    forgot_password_ip_limiter,
+    login_email_limiter,
+    login_ip_limiter,
+    register_ip_limiter,
 )
-
-
-@pytest.fixture(autouse=True)
-def _reset_rate_limiters():
-    """Reset all rate limiter state between tests to avoid cross-test pollution."""
-    yield
-    for limiter in (
-        login_ip_limiter,
-        login_email_limiter,
-        register_ip_limiter,
-        forgot_password_ip_limiter,
-        forgot_password_email_limiter,
-    ):
-        limiter._attempts.clear()
-
 
 # --- API Endpoint Tests ---
 

--- a/tests/test_htmx.py
+++ b/tests/test_htmx.py
@@ -8,33 +8,14 @@ Convention: HTMX requests send the HX-Request: true header.
 - Non-HTMX paths remain unchanged (303 RedirectResponse or full-page error).
 """
 
-import pytest
 from starlette.requests import Request
 from fastapi.templating import Jinja2Templates
 from tests.conftest import htmx_headers
 from utils.core.htmx import is_htmx_request, toast_response, append_toast
 from utils.core.rate_limit import (
-    login_ip_limiter,
-    login_email_limiter,
-    register_ip_limiter,
     forgot_password_ip_limiter,
-    forgot_password_email_limiter,
+    login_ip_limiter,
 )
-
-
-@pytest.fixture(autouse=True)
-def _reset_rate_limiters():
-    """Reset all rate limiter state between tests."""
-    yield
-    for limiter in (
-        login_ip_limiter,
-        login_email_limiter,
-        register_ip_limiter,
-        forgot_password_ip_limiter,
-        forgot_password_email_limiter,
-    ):
-        limiter._attempts.clear()
-
 
 # ---------------------------------------------------------------------------
 # 1.3 — is_htmx_request helper

--- a/utils/core/organizations.py
+++ b/utils/core/organizations.py
@@ -1,5 +1,7 @@
+from typing import Any, cast
+
 from sqlmodel import Session, select
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import InstrumentedAttribute, selectinload
 
 from utils.core.models import Organization, Role, User, Invitation
 
@@ -21,13 +23,15 @@ def load_org_for_members_partial(
         select(Organization)
         .where(Organization.id == organization_id)
         .options(
-            selectinload(Organization.roles)
-            .selectinload(Role.users)
-            .selectinload(User.account),
-            selectinload(Organization.roles)
-            .selectinload(Role.users)
-            .selectinload(User.roles),
-            selectinload(Organization.roles).selectinload(Role.permissions),
+            selectinload(cast(InstrumentedAttribute[Any], Organization.roles))
+            .selectinload(cast(InstrumentedAttribute[Any], Role.users))
+            .selectinload(cast(InstrumentedAttribute[Any], User.account)),
+            selectinload(cast(InstrumentedAttribute[Any], Organization.roles))
+            .selectinload(cast(InstrumentedAttribute[Any], Role.users))
+            .selectinload(cast(InstrumentedAttribute[Any], User.roles)),
+            selectinload(
+                cast(InstrumentedAttribute[Any], Organization.roles)
+            ).selectinload(cast(InstrumentedAttribute[Any], Role.permissions)),
         )
     ).first()
     user_permissions = _user_permissions_for_org(user, organization_id)
@@ -43,8 +47,12 @@ def load_org_for_roles_partial(
         select(Organization)
         .where(Organization.id == organization_id)
         .options(
-            selectinload(Organization.roles).selectinload(Role.users),
-            selectinload(Organization.roles).selectinload(Role.permissions),
+            selectinload(
+                cast(InstrumentedAttribute[Any], Organization.roles)
+            ).selectinload(cast(InstrumentedAttribute[Any], Role.users)),
+            selectinload(
+                cast(InstrumentedAttribute[Any], Organization.roles)
+            ).selectinload(cast(InstrumentedAttribute[Any], Role.permissions)),
         )
     ).first()
     user_permissions = _user_permissions_for_org(user, organization_id)

--- a/utils/core/rate_limit.py
+++ b/utils/core/rate_limit.py
@@ -154,6 +154,20 @@ forgot_password_email_limiter = RateLimitWindow(
     window_seconds=_int_env("FORGOT_PASSWORD_EMAIL_WINDOW_SECONDS", 60),
 )
 
+_ALL_LIMITERS = (
+    login_ip_limiter,
+    login_email_limiter,
+    register_ip_limiter,
+    forgot_password_ip_limiter,
+    forgot_password_email_limiter,
+)
+
+
+def clear_all_rate_limiters() -> None:
+    """Clear all in-memory rate limiter state."""
+    for limiter in _ALL_LIMITERS:
+        limiter._attempts.clear()
+
 
 # --- Dependency helpers ---
 


### PR DESCRIPTION
## Summary
- Add `InstrumentedAttribute[Any]` casts on all `selectinload` chains in `utils/core/organizations.py` per the SQLModel typing rule.
- Introduce `clear_all_rate_limiters()` and a session-wide autouse fixture in `tests/conftest.py` that resets limiters before and after every test.
- Remove duplicate module-local rate limiter reset fixtures from `tests/test_htmx.py` and `tests/routers/core/test_account.py`.

Closes #201

## Test plan
- [x] `uv run ty check .`
- [x] `uv run pytest tests`


Made with [Cursor](https://cursor.com)