### PR TITLE
fix: revoke sessions on password reset

### DIFF
--- a/routers/core/account.py
+++ b/routers/core/account.py
@@ -734,6 +734,8 @@ async def reset_password(
     session.commit()
     session.refresh(authorized_account)
 
+    revoke_all_refresh_tokens(authorized_account.id, session)
+
     # Auto-login: issue new auth cookies so the user doesn't have to re-enter credentials
     access_token = create_access_token(
         data={"sub": authorized_account.email, "fresh": True}

--- a/tests/routers/core/test_account.py
+++ b/tests/routers/core/test_account.py
@@ -706,6 +706,46 @@ def test_password_reset_auto_logs_in_and_shows_flash(
     assert any("flash_message=" in c for c in cookie_headers)
 
 
+def test_password_reset_revokes_existing_sessions(
+    unauth_client: TestClient, session: Session, test_account: Account
+):
+    """Password reset revokes all existing refresh tokens before auto-login."""
+    attacker_session = RefreshToken(
+        account_id=test_account.id,
+        expires_at=datetime.now(UTC) + timedelta(days=30),
+    )
+    session.add(attacker_session)
+    session.commit()
+    session.refresh(attacker_session)
+
+    reset_token = PasswordResetToken(account_id=test_account.id)
+    session.add(reset_token)
+    session.commit()
+    session.refresh(reset_token)
+
+    response = unauth_client.post(
+        app.url_path_for("reset_password"),
+        data={
+            "email": test_account.email,
+            "token": reset_token.token,
+            "password": "NewPass123!@#",
+            "confirm_password": "NewPass123!@#",
+        },
+    )
+    assert response.status_code == 303
+
+    session.refresh(attacker_session)
+    assert attacker_session.revoked is True
+
+    active_tokens = session.exec(
+        select(RefreshToken).where(
+            RefreshToken.account_id == test_account.id,
+            RefreshToken.revoked == False,  # noqa: E712
+        )
+    ).all()
+    assert len(active_tokens) == 1
+
+
 def test_password_reset_after_recovery_auto_logs_in(
     unauth_client: TestClient, session: Session
 ):


### PR DESCRIPTION
## Summary
- Revoke all refresh tokens in `reset_password` before issuing the new auto-login session, matching `recover_account` and `promote_email`.
- Add regression test ensuring an attacker's pre-existing refresh token is revoked while the reset flow still issues exactly one new active token.

Closes #214

## Context
Security audit finding M1: resetting a password is the standard response to a suspected compromise, but the reset flow previously left other active sessions valid.

## Test plan
- [x] `uv run pytest tests/routers/core/test_account.py::test_password_reset_revokes_existing_sessions`
- [x] `uv run ty check .`