### PR TITLE
fix: add CSRF tokens and convert account recovery to POST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ DB_NAME=
 # Domain for production (used by Caddy for TLS)
 DOMAIN=
 
+# Set to 0 to disable CSRF checks (not recommended in production)
+# CSRF_ENABLED=1
+
 # Resend
 RESEND_API_KEY=
 EMAIL_FROM=

--- a/exceptions/http_exceptions.py
+++ b/exceptions/http_exceptions.py
@@ -246,3 +246,10 @@ class InvitationProcessingError(HTTPException):
             status_code=500,  # Internal Server Error
             detail=detail,
         )
+
+
+class CsrfError(HTTPException):
+    """Raised when CSRF validation fails."""
+
+    def __init__(self):
+        super().__init__(status_code=403, detail="CSRF validation failed")

--- a/main.py
+++ b/main.py
@@ -21,6 +21,15 @@ from utils.core.dependencies import (
     require_unauthenticated_client,
 )
 from utils.core.auth import refresh_token_is_persistent, set_auth_cookies
+from utils.core.csrf import (
+    CSRF_COOKIE_NAME,
+    UNSAFE_HTTP_METHODS,
+    csrf_enabled,
+    extract_submitted_csrf_token,
+    generate_csrf_token,
+    set_csrf_cookie,
+    validate_csrf_token,
+)
 from utils.core.htmx import (
     is_htmx_request,
     toast_response,
@@ -30,6 +39,7 @@ from utils.core.htmx import (
 from exceptions.http_exceptions import (
     AlreadyAuthenticatedError,
     AuthenticationError,
+    CsrfError,
     PasswordValidationError,
     CredentialsError,
     RateLimitError,
@@ -70,6 +80,22 @@ async def flash_cookie_middleware(request: Request, call_next):
     response = await call_next(request)
     if flash:
         response.delete_cookie(FLASH_COOKIE_NAME, path="/")
+    return response
+
+
+@app.middleware("http")
+async def csrf_middleware(request: Request, call_next):
+    token = request.cookies.get(CSRF_COOKIE_NAME) or generate_csrf_token()
+    request.state.csrf_token = token
+
+    if csrf_enabled() and request.method in UNSAFE_HTTP_METHODS:
+        submitted = await extract_submitted_csrf_token(request)
+        if not validate_csrf_token(request, submitted):
+            return await csrf_error_handler(request, CsrfError())
+
+    response = await call_next(request)
+    if request.cookies.get(CSRF_COOKIE_NAME) != token:
+        set_csrf_cookie(response, token)
     return response
 
 
@@ -135,6 +161,25 @@ async def rate_limit_error_handler(request: Request, exc: RateLimitError):
     )
     response.headers["Retry-After"] = str(exc.retry_after)
     return response
+
+
+@app.exception_handler(CsrfError)
+async def csrf_error_handler(request: Request, exc: CsrfError):
+    if is_htmx_request(request):
+        return toast_response(
+            request,
+            templates,
+            exc.detail,
+            level="danger",
+            status_code=403,
+        )
+    user = await get_user_from_request(request)
+    return templates.TemplateResponse(
+        request,
+        "errors/error.html",
+        {"status_code": 403, "detail": exc.detail, "errors": None, "user": user},
+        status_code=403,
+    )
 
 
 # Handle CredentialsError (invalid email/password) with toast for HTMX

--- a/routers/core/account.py
+++ b/routers/core/account.py
@@ -765,8 +765,27 @@ async def reset_password(
 
 
 @router.get("/recover")
-async def recover_account(
+async def recover_account_confirm(
+    request: Request,
     token: str = Query(...),
+    session: Session = Depends(get_session),
+):
+    """Show a confirmation form before performing account recovery."""
+    account, recovery_token = get_account_from_recovery_token(token, session)
+
+    if not account or not recovery_token:
+        raise CredentialsError(message="Invalid or expired recovery token")
+
+    return templates.TemplateResponse(
+        request,
+        "account/recover_confirm.html",
+        {"token": token, "user": None},
+    )
+
+
+@router.post("/recover")
+async def recover_account(
+    token: str = Form(...),
     session: Session = Depends(get_session),
 ):
     """
@@ -1023,7 +1042,6 @@ async def promote_email(
         access_token,
         refresh_token,
         persistent=False,
-        samesite="lax",
     )
     return response
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -16,6 +16,13 @@ document.body.addEventListener('htmx:configRequest', function() {
     }
 }, { once: true });
 
+document.body.addEventListener('htmx:configRequest', function(event) {
+    var meta = document.querySelector('meta[name="csrf-token"]');
+    if (meta && meta.content) {
+        event.detail.headers['X-CSRF-Token'] = meta.content;
+    }
+});
+
 
 // When a modal closes, reset any create-* form it contains so reopening it
 // starts blank. ui.js dispatches 'hidden.bs.modal' when a modal is hidden.

--- a/templates/account/forgot_password.html
+++ b/templates/account/forgot_password.html
@@ -1,5 +1,6 @@
 {% extends "account/auth_base.html" %}
 
+
 {% block title %}Forgot Password{% endblock %}
 
 {% block auth_header %}Forgot Password{% endblock %}
@@ -10,6 +11,7 @@
     <form method="POST" action="{{ url_for('forgot_password') }}"
           hx-post="{{ url_for('forgot_password') }}" hx-swap="none"
           class="needs-validation" novalidate>
+          {% include 'base/partials/csrf_field.html' %}
         <!-- Email Input -->
         <div class="mb-3">
             <label for="email" class="form-label">Email</label>

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,5 +1,6 @@
 {% extends "account/auth_base.html" %}
 
+
 {% set show_warning_only = user and invitation_token_warning %}
 {% set warning_heading = "Invitation link expired" if invitation_token_warning == 'expired' else "Invitation link invalid" %}
 
@@ -27,6 +28,7 @@
     <form method="POST" action="{{ url_for('login') }}"
           hx-post="{{ url_for('login') }}" hx-swap="none"
           class="needs-validation" novalidate>
+          {% include 'base/partials/csrf_field.html' %}
         {# Add hidden input for invitation token if present #}
         {% if invitation_token %}
         <input type="hidden" name="invitation_token" value="{{ invitation_token }}">

--- a/templates/account/recover_confirm.html
+++ b/templates/account/recover_confirm.html
@@ -1,0 +1,16 @@
+{% extends "account/auth_base.html" %}
+
+
+{% block auth_header %}Recover Your Account{% endblock %}
+
+{% block auth_content %}
+<p class="mb-4">
+    Use this page to restore your account email and sign out all active sessions.
+    You will be asked to set a new password after confirming.
+</p>
+<form action="{{ url_for('recover_account') }}" method="post">
+    {% include 'base/partials/csrf_field.html' %}
+    <input type="hidden" name="token" value="{{ token }}">
+    <button type="submit" class="btn btn-primary w-100">Recover account</button>
+</form>
+{% endblock %}

--- a/templates/account/register.html
+++ b/templates/account/register.html
@@ -1,5 +1,6 @@
 {% extends "account/auth_base.html" %}
 
+
 {% set show_warning_only = user and invitation_token_warning %}
 {% set warning_heading = "Invitation link expired" if invitation_token_warning == 'expired' else "Invitation link invalid" %}
 
@@ -27,6 +28,7 @@
     <form method="POST" action="{{ url_for('register') }}"
           hx-post="{{ url_for('register') }}" hx-swap="none"
           class="needs-validation" novalidate>
+          {% include 'base/partials/csrf_field.html' %}
         {# Add hidden input for invitation token if present #}
         {% if invitation_token %}
         <input type="hidden" name="invitation_token" value="{{ invitation_token }}">

--- a/templates/account/reset_password.html
+++ b/templates/account/reset_password.html
@@ -1,5 +1,6 @@
 {% extends "account/auth_base.html" %}
 
+
 {% block title %}Reset Password{% endblock %}
 
 {% block auth_header %}Reset Password{% endblock %}
@@ -9,6 +10,7 @@
     <form method="POST" action="{{ url_for('reset_password') }}"
           hx-post="{{ url_for('reset_password') }}" hx-swap="none"
           class="needs-validation" novalidate>
+          {% include 'base/partials/csrf_field.html' %}
         <!-- Hidden Email Input -->
         <input type="hidden" name="email" value="{{ email }}">
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
     <link rel="mask-icon" href="{{ url_for('static', path='safari-pinned-tab.svg') }}" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
+    <meta name="csrf-token" content="{{ request.state.csrf_token }}">
     <!-- Scripts in <head> with defer so they are NOT re-processed during
          htmx hx-boost body swaps. This keeps our component JS (ui.js) and its
          document-level event delegation working across AJAX navigations. defer

--- a/templates/base/partials/csrf_field.html
+++ b/templates/base/partials/csrf_field.html
@@ -1,0 +1,1 @@
+<input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">

--- a/templates/organization/modals/delete_organization_modal.html
+++ b/templates/organization/modals/delete_organization_modal.html
@@ -1,3 +1,4 @@
+
 {# Delete Organization Modal #}
 {% if ValidPermissions.DELETE_ORGANIZATION in user_permissions %}
 <div class="modal fade" id="deleteOrganizationModal" tabindex="-1" aria-labelledby="deleteOrganizationModalLabel" aria-hidden="true">
@@ -5,6 +6,7 @@
     <div class="modal-content">
       <form method="POST" action="{{ url_for('delete_organization', org_id=organization.id) }}"
             hx-post="{{ url_for('delete_organization', org_id=organization.id) }}">
+            {% include 'base/partials/csrf_field.html' %}
         <div class="modal-header">
           <h5 class="modal-title" id="deleteOrganizationModalLabel">Delete Organization</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/templates/organization/modals/edit_organization_modal.html
+++ b/templates/organization/modals/edit_organization_modal.html
@@ -1,3 +1,4 @@
+
 {# Edit Organization Modal #}
 {% if ValidPermissions.EDIT_ORGANIZATION in user_permissions %}
 <div class="modal fade" id="editOrganizationModal" tabindex="-1" aria-labelledby="editOrganizationModalLabel" aria-hidden="true">
@@ -5,6 +6,7 @@
     <div class="modal-content">
       <form method="POST" action="{{ url_for('update_organization', org_id=organization.id) }}"
             hx-post="{{ url_for('update_organization', org_id=organization.id) }}">
+            {% include 'base/partials/csrf_field.html' %}
         <div class="modal-header">
           <h5 class="modal-title" id="editOrganizationModalLabel">Edit Organization</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/templates/organization/modals/members_card.html
+++ b/templates/organization/modals/members_card.html
@@ -1,3 +1,4 @@
+
 {% from 'base/macros/silhouette.html' import render_silhouette %}
 
 <!-- Organization Members -->
@@ -61,6 +62,7 @@
                                   hx-target="#members-card-content"
                                   hx-swap="innerHTML"
                                   hx-confirm="Remove {{ member.name }} from this organization?">
+                                  {% include 'base/partials/csrf_field.html' %}
                                 <input type="hidden" name="user_id" value="{{ member.id }}">
                                 <input type="hidden" name="organization_id" value="{{ organization.id }}">
                                 <button type="submit" class="btn btn-sm btn-outline-danger" {% if member.id == user.id %}disabled{% endif %}>
@@ -96,6 +98,7 @@
             hx-post="{{ url_for('create_invitation') }}"
             hx-target="#members-card-content"
             hx-swap="innerHTML">
+            {% include 'base/partials/csrf_field.html' %}
         <div class="modal-header">
           <h5 class="modal-title" id="inviteMemberModalLabel">Invite New Member</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -137,6 +140,7 @@
                 hx-post="{{ url_for('update_user_role') }}"
                 hx-target="#members-card-content"
                 hx-swap="innerHTML">
+                {% include 'base/partials/csrf_field.html' %}
             <div class="modal-header">
               <h5 class="modal-title" id="editUserRoleModalLabel{{ member.id }}">Edit Roles for {{ member.name }}</h5>
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/templates/organization/modals/roles_card.html
+++ b/templates/organization/modals/roles_card.html
@@ -1,3 +1,4 @@
+
 <!-- Organization Roles -->
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
@@ -55,6 +56,7 @@
                                       hx-target="#roles-card-content"
                                       hx-swap="innerHTML"
                                       hx-confirm="Are you sure you want to delete this role?">
+                                      {% include 'base/partials/csrf_field.html' %}
                                     <input type="hidden" name="id" value="{{ role.id }}">
                                     <input type="hidden" name="organization_id" value="{{ organization.id }}">
                                     <button type="submit" class="btn btn-sm btn-outline-danger" {% if role.users|length > 0 %}disabled{% endif %}>
@@ -84,6 +86,7 @@
             hx-post="{{ url_for('create_role') }}"
             hx-target="#roles-card-content"
             hx-swap="innerHTML">
+            {% include 'base/partials/csrf_field.html' %}
         <div class="modal-header">
           <h5 class="modal-title" id="createRoleModalLabel">Create New Role</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -131,6 +134,7 @@
                 hx-post="{{ url_for('update_role') }}"
                 hx-target="#roles-card-content"
                 hx-swap="innerHTML">
+                {% include 'base/partials/csrf_field.html' %}
             <div class="modal-header">
               <h5 class="modal-title" id="editRoleModalLabel{{ role.id }}">Edit Role: {{ role.name }}</h5>
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/templates/organization/partials/invitations_list.html
+++ b/templates/organization/partials/invitations_list.html
@@ -1,3 +1,4 @@
+
 {# Partial: <li> items for pending invitations. Swapped into <ul id="invitations-list">. #}
 {# Set show_invitation_cancel=true via {% with %} to render Resend/Cancel controls (members card only). #}
 {% for inv in pending_invitations %}
@@ -19,6 +20,7 @@
                   hx-post="{{ url_for('resend_invitation') }}"
                   hx-target="#members-card-content"
                   hx-swap="innerHTML">
+                  {% include 'base/partials/csrf_field.html' %}
                 <input type="hidden" name="invitation_id" value="{{ inv.id }}">
                 <input type="hidden" name="organization_id" value="{{ organization.id }}">
                 <button type="submit" class="btn btn-sm btn-outline-primary btn-invitation-resend">
@@ -30,6 +32,7 @@
                   hx-target="#members-card-content"
                   hx-swap="innerHTML"
                   hx-confirm="Cancel invitation for {{ inv.invitee_email }}?">
+                  {% include 'base/partials/csrf_field.html' %}
                 <input type="hidden" name="invitation_id" value="{{ inv.id }}">
                 <input type="hidden" name="organization_id" value="{{ organization.id }}">
                 <button type="submit" class="btn btn-sm btn-outline-danger">

--- a/templates/organization/partials/member_row.html
+++ b/templates/organization/partials/member_row.html
@@ -1,3 +1,4 @@
+
 {# Partial: single member <tr>. Swapped into <tr id="member-row-{{ member.id }}"> via outerHTML. #}
 {% from 'base/macros/silhouette.html' import render_silhouette %}
 <tr id="member-row-{{ member.id }}">
@@ -31,6 +32,7 @@
               hx-target="#members-card-content"
               hx-swap="innerHTML"
               hx-confirm="Remove {{ member.name }} from this organization?">
+              {% include 'base/partials/csrf_field.html' %}
             <input type="hidden" name="user_id" value="{{ member.id }}">
             <input type="hidden" name="organization_id" value="{{ organization.id }}">
             <button type="submit" class="btn btn-sm btn-outline-danger" {% if member.id == user.id %}disabled{% endif %}>

--- a/templates/organization/partials/members_table.html
+++ b/templates/organization/partials/members_table.html
@@ -1,3 +1,4 @@
+
 {# Partial: card-body content for members. Swapped into #members-card-content. #}
 {% from 'base/macros/silhouette.html' import render_silhouette %}
 {% if organization.users|length <= 1 %}
@@ -49,6 +50,7 @@
                           hx-target="#members-card-content"
                           hx-swap="innerHTML"
                           hx-confirm="Remove {{ member.name }} from this organization?">
+                          {% include 'base/partials/csrf_field.html' %}
                         <input type="hidden" name="user_id" value="{{ member.id }}">
                         <input type="hidden" name="organization_id" value="{{ organization.id }}">
                         <button type="submit" class="btn btn-sm btn-outline-danger" {% if member.id == user.id %}disabled{% endif %}>
@@ -83,6 +85,7 @@
                 hx-post="{{ url_for('update_user_role') }}"
                 hx-target="#members-card-content"
                 hx-swap="innerHTML">
+                {% include 'base/partials/csrf_field.html' %}
             <div class="modal-header">
               <h5 class="modal-title" id="editUserRoleModalLabel{{ member.id }}">Edit Roles for {{ member.name }}</h5>
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/templates/organization/partials/role_row.html
+++ b/templates/organization/partials/role_row.html
@@ -1,3 +1,4 @@
+
 {# Partial: single role <tr>. Swapped into <tr id="role-row-{{ role.id }}"> via outerHTML. #}
 <tr id="role-row-{{ role.id }}">
     <td>{{ role.name }}</td>
@@ -23,6 +24,7 @@
               hx-target="#roles-card-content"
               hx-swap="innerHTML"
               hx-confirm="Are you sure you want to delete this role?">
+              {% include 'base/partials/csrf_field.html' %}
             <input type="hidden" name="id" value="{{ role.id }}">
             <input type="hidden" name="organization_id" value="{{ organization.id }}">
             <button type="submit" class="btn btn-sm btn-outline-danger" {% if role.users|length > 0 %}disabled{% endif %}>

--- a/templates/organization/partials/roles_table.html
+++ b/templates/organization/partials/roles_table.html
@@ -1,3 +1,4 @@
+
 {# Partial: card-body content for roles. Swapped into #roles-card-content. #}
 {% if organization.roles %}
 <div class="table-responsive">
@@ -38,6 +39,7 @@
                           hx-target="#roles-card-content"
                           hx-swap="innerHTML"
                           hx-confirm="Are you sure you want to delete this role?">
+                          {% include 'base/partials/csrf_field.html' %}
                         <input type="hidden" name="id" value="{{ role.id }}">
                         <input type="hidden" name="organization_id" value="{{ organization.id }}">
                         <button type="submit" class="btn btn-sm btn-outline-danger" {% if role.users|length > 0 %}disabled{% endif %}>
@@ -67,6 +69,7 @@
                 hx-post="{{ url_for('update_role') }}"
                 hx-target="#roles-card-content"
                 hx-swap="innerHTML">
+                {% include 'base/partials/csrf_field.html' %}
             <div class="modal-header">
               <h5 class="modal-title" id="editRoleModalLabel{{ role.id }}">Edit Role: {{ role.name }}</h5>
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/templates/users/macros/organizations.html
+++ b/templates/users/macros/organizations.html
@@ -1,3 +1,4 @@
+
 {% macro render_organizations(organizations) %}
 <div class="card mb-4 profile-organizations-card">
     <div class="card-header d-flex flex-wrap justify-content-between align-items-start align-items-md-center gap-2 profile-organizations-card-header">
@@ -10,6 +11,8 @@
         <!-- New Organization Form -->
         <div class="collapse mb-3" id="newOrgForm">
             <form action="{{ url_for('create_organization') }}" method="post" class="border rounded p-3 bg-light">
+        {% include 'base/partials/csrf_field.html' %}
+        {% include 'base/partials/csrf_field.html' %}
                 <div class="mb-3">
                     <label for="name" class="form-label">Organization Name</label>
                     <input type="text" 

--- a/templates/users/partials/profile_form.html
+++ b/templates/users/partials/profile_form.html
@@ -1,3 +1,4 @@
+
 {# Partial: profile edit form card. Swapped into #profile-card. #}
 <div class="card-header">
     Edit Profile
@@ -8,6 +9,7 @@
           hx-target="#profile-card"
           hx-swap="innerHTML"
           hx-encoding="multipart/form-data">
+          {% include 'base/partials/csrf_field.html' %}
         <div class="mb-3">
             <label for="name" class="form-label">Name</label>
             <input type="text" class="form-control" id="name" name="name" value="{{ user.name }}">

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+
 {% from 'users/macros/organizations.html' import render_organizations with context %}
 
 {% block title %}Profile{% endblock %}
@@ -20,6 +21,7 @@
         <div class="card-body">
             <form action="{{ url_for('update_communication_preferences') }}" method="post"
                   hx-post="{{ url_for('update_communication_preferences') }}" hx-swap="none">
+                  {% include 'base/partials/csrf_field.html' %}
                 {% include 'partials/communication_preferences_fields.html' with context %}
                 <button type="submit" class="btn btn-primary mt-3">Save Preferences</button>
             </form>
@@ -51,6 +53,7 @@
                             {% if not email.is_primary and email.verified %}
                             <form action="{{ url_for('promote_email') }}" method="post" class="profile-email-action-form mb-0"
                                   hx-post="{{ url_for('promote_email') }}" hx-swap="none">
+                                  {% include 'base/partials/csrf_field.html' %}
                                 <input type="hidden" name="email_id" value="{{ email.id }}">
                                 <button type="submit" class="btn btn-sm btn-outline-primary">Make Primary</button>
                             </form>
@@ -58,6 +61,7 @@
                             {% if not email.is_primary %}
                             <form action="{{ url_for('remove_email') }}" method="post" class="profile-email-action-form mb-0"
                                   hx-post="{{ url_for('remove_email') }}" hx-swap="none">
+                                  {% include 'base/partials/csrf_field.html' %}
                                 <input type="hidden" name="email_id" value="{{ email.id }}">
                                 <button type="submit" class="btn btn-sm btn-outline-danger">Remove</button>
                             </form>
@@ -73,6 +77,7 @@
             <form action="{{ url_for('add_email') }}" method="post" class="profile-add-email-form"
                   hx-post="{{ url_for('add_email') }}" hx-swap="none"
                   hx-on::after-settle="this.reset()">
+                  {% include 'base/partials/csrf_field.html' %}
                 <div class="input-group">
                     <input type="email" class="form-control" name="new_email" placeholder="Add Email Address" required>
                     <button type="submit" class="btn btn-primary">Add Email</button>
@@ -91,6 +96,8 @@
         <div class="card-body">
             {% if show_form %}
             <form action="{{ url_for('forgot_password') }}" method="post">
+        {% include 'base/partials/csrf_field.html' %}
+        {% include 'base/partials/csrf_field.html' %}
                 <input type="hidden" name="email" value="{{ user.account.email }}">
                 <p>To change your password, please confirm your email. A password reset link will be sent to your email address.</p>
                 <button type="submit" class="btn btn-primary">Send Password Reset Email</button>
@@ -111,6 +118,8 @@
         </div>
         <div class="card-body">
             <form action="{{ url_for('delete_account') }}" method="post">
+        {% include 'base/partials/csrf_field.html' %}
+        {% include 'base/partials/csrf_field.html' %}
                 <p class="text-danger">This action cannot be undone. Please confirm your email and password to delete your account.</p>
                 <div class="mb-3">
                     <label for="delete_email" class="form-label">Email</label>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def env_vars(monkeypatch):
         m.setenv("RESEND_API_KEY", "test")
         m.setenv("EMAIL_FROM", "test@example.com")
         m.setenv("BASE_URL", "http://localhost:8000")
+        m.setenv("CSRF_ENABLED", "0")
         yield
 
 

--- a/tests/routers/core/test_account.py
+++ b/tests/routers/core/test_account.py
@@ -792,11 +792,8 @@ def test_password_reset_after_recovery_auto_logs_in(
     session.commit()
     session.refresh(recovery_token)
 
-    # Step 1: Hit recovery endpoint
-    recovery_response = unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    # Step 1: Confirm and submit recovery
+    recovery_response = _submit_account_recovery(unauth_client, recovery_token.token)
     assert recovery_response.status_code == 303
     reset_location = recovery_response.headers["location"]
     assert "reset_password" in reset_location
@@ -1659,6 +1656,35 @@ def test_promote_email_swaps_primary(
     assert test_account_email.is_primary is False
 
 
+def test_promote_email_reissues_auth_cookies_with_strict_samesite(
+    auth_client: TestClient,
+    test_account: Account,
+    test_account_email,
+    session: Session,
+    mock_resend_send,
+):
+    secondary = AccountEmail(
+        account_id=test_account.id,
+        email="secondary@example.com",
+        is_primary=False,
+        verified=True,
+        verified_at=datetime.now(UTC),
+    )
+    session.add(secondary)
+    session.commit()
+    session.refresh(secondary)
+
+    response = auth_client.post(
+        app.url_path_for("promote_email"),
+        data={"email_id": secondary.id},
+    )
+
+    cookie_headers = response.headers.get_list("set-cookie")
+    auth_cookies = [header for header in cookie_headers if "access_token=" in header]
+    assert auth_cookies
+    assert all("samesite=strict" in header.lower() for header in auth_cookies)
+
+
 def test_promote_email_updates_account_email_field(
     auth_client: TestClient,
     test_account: Account,
@@ -2322,16 +2348,40 @@ def _setup_compromised_account(session: Session) -> tuple:
     return account, recovery_token, original_email
 
 
+def _get_recovery_confirm(unauth_client: TestClient, token: str):
+    return unauth_client.get(
+        app.url_path_for("recover_account_confirm"),
+        params={"token": token},
+    )
+
+
+def _submit_account_recovery(unauth_client: TestClient, token: str):
+    confirm = _get_recovery_confirm(unauth_client, token)
+    assert confirm.status_code == 200
+    return unauth_client.post(
+        app.url_path_for("recover_account"),
+        data={"token": token},
+    )
+
+
+def test_recover_account_confirm_page_shows_form(
+    unauth_client: TestClient, session: Session
+):
+    _, recovery_token, _ = _setup_compromised_account(session)
+
+    response = _get_recovery_confirm(unauth_client, recovery_token.token)
+
+    assert response.status_code == 200
+    assert "Recover account" in response.text
+
+
 def test_recover_account_restores_email_as_primary(
     unauth_client: TestClient, session: Session
 ):
     """Test that recovery restores the victim's email as primary."""
     account, recovery_token, original_email = _setup_compromised_account(session)
 
-    response = unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    response = _submit_account_recovery(unauth_client, recovery_token.token)
     assert response.status_code == 303
 
     session.refresh(account)
@@ -2353,10 +2403,7 @@ def test_recover_account_removes_attacker_emails(
     """Test that recovery removes all existing AccountEmail rows (attacker's emails)."""
     account, recovery_token, original_email = _setup_compromised_account(session)
 
-    unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    _submit_account_recovery(unauth_client, recovery_token.token)
 
     all_emails = session.exec(
         select(AccountEmail).where(AccountEmail.account_id == account.id)
@@ -2378,10 +2425,7 @@ def test_recover_account_revokes_all_sessions(
     session.add(rt)
     session.commit()
 
-    unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    _submit_account_recovery(unauth_client, recovery_token.token)
 
     session.refresh(rt)
     assert rt.revoked is True
@@ -2393,10 +2437,7 @@ def test_recover_account_generates_password_reset_token(
     """Test that recovery creates a PasswordResetToken."""
     account, recovery_token, _ = _setup_compromised_account(session)
 
-    unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    _submit_account_recovery(unauth_client, recovery_token.token)
 
     reset_token = session.exec(
         select(PasswordResetToken).where(
@@ -2413,10 +2454,7 @@ def test_recover_account_redirects_to_reset_password(
     """Test that recovery redirects to the reset password page."""
     account, recovery_token, original_email = _setup_compromised_account(session)
 
-    response = unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    response = _submit_account_recovery(unauth_client, recovery_token.token)
     assert response.status_code == 303
     location = response.headers["location"]
     assert "/account/reset_password" in location
@@ -2427,10 +2465,7 @@ def test_recover_account_marks_token_used(unauth_client: TestClient, session: Se
     """Test that the recovery token is marked as used after recovery."""
     account, recovery_token, _ = _setup_compromised_account(session)
 
-    unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    _submit_account_recovery(unauth_client, recovery_token.token)
 
     session.refresh(recovery_token)
     assert recovery_token.used is True
@@ -2444,10 +2479,7 @@ def test_recover_account_expired_token_fails(
     recovery_token.expires_at = datetime.now(UTC) - timedelta(hours=1)
     session.commit()
 
-    response = unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    response = _get_recovery_confirm(unauth_client, recovery_token.token)
     assert response.status_code == 401
 
 
@@ -2457,10 +2489,7 @@ def test_recover_account_used_token_fails(unauth_client: TestClient, session: Se
     recovery_token.used = True
     session.commit()
 
-    response = unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    response = _get_recovery_confirm(unauth_client, recovery_token.token)
     assert response.status_code == 401
 
 
@@ -2468,10 +2497,7 @@ def test_recover_account_invalid_token_fails(
     unauth_client: TestClient, session: Session
 ):
     """Test that a nonexistent recovery token fails."""
-    response = unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": "nonexistent-token"},
-    )
+    response = _get_recovery_confirm(unauth_client, "nonexistent-token")
     assert response.status_code == 401
 
 
@@ -2496,10 +2522,7 @@ def test_recover_account_readds_removed_email(
     session.commit()
     session.refresh(recovery_token)
 
-    response = unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    response = _submit_account_recovery(unauth_client, recovery_token.token)
     assert response.status_code == 303
 
     session.refresh(account)
@@ -2558,10 +2581,7 @@ def test_recover_account_when_victim_email_still_exists_as_account_email(
     session.commit()
     session.refresh(recovery_token)
 
-    response = unauth_client.get(
-        app.url_path_for("recover_account"),
-        params={"token": recovery_token.token},
-    )
+    response = _submit_account_recovery(unauth_client, recovery_token.token)
     assert response.status_code == 303
 
     # Verify the victim's email is now the only AccountEmail and is primary

--- a/tests/utils/test_csrf.py
+++ b/tests/utils/test_csrf.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from main import app
+from utils.core.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_FORM_FIELD,
+    CSRF_HEADER_NAME,
+    generate_csrf_token,
+    validate_csrf_token,
+)
+
+
+def test_validate_csrf_token_accepts_matching_values():
+    request = MagicMock()
+    token = generate_csrf_token()
+    request.state.csrf_token = token
+    assert validate_csrf_token(request, token) is True
+
+
+def test_validate_csrf_token_rejects_mismatch():
+    request = MagicMock()
+    request.state.csrf_token = generate_csrf_token()
+    assert validate_csrf_token(request, generate_csrf_token()) is False
+
+
+def test_post_without_csrf_rejected_when_enabled(
+    unauth_client: TestClient, monkeypatch
+):
+    monkeypatch.setenv("CSRF_ENABLED", "1")
+    token = generate_csrf_token()
+    unauth_client.cookies.set(CSRF_COOKIE_NAME, token)
+
+    response = unauth_client.post(
+        app.url_path_for("login"),
+        data={"email": "test@example.com", "password": "Password123!@#"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_post_with_form_csrf_accepted_when_enabled(
+    unauth_client: TestClient, test_account, monkeypatch
+):
+    monkeypatch.setenv("CSRF_ENABLED", "1")
+    token = generate_csrf_token()
+    unauth_client.cookies.set(CSRF_COOKIE_NAME, token)
+
+    response = unauth_client.post(
+        app.url_path_for("login"),
+        data={
+            CSRF_FORM_FIELD: token,
+            "email": test_account.email,
+            "password": "Test123!@#",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code != 403
+
+
+def test_post_with_header_csrf_accepted_when_enabled(
+    unauth_client: TestClient, monkeypatch
+):
+    monkeypatch.setenv("CSRF_ENABLED", "1")
+    token = generate_csrf_token()
+    unauth_client.cookies.set(CSRF_COOKIE_NAME, token)
+
+    response = unauth_client.post(
+        app.url_path_for("forgot_password"),
+        data={"email": "missing@example.com"},
+        headers={CSRF_HEADER_NAME: token},
+    )
+
+    assert response.status_code != 403

--- a/utils/core/csrf.py
+++ b/utils/core/csrf.py
@@ -1,0 +1,64 @@
+import os
+import secrets
+from typing import Final
+
+from fastapi import Request
+from starlette.responses import Response
+
+from utils.core.auth import COOKIE_SECURE
+
+CSRF_COOKIE_NAME: Final = "csrf_token"
+CSRF_HEADER_NAME: Final = "x-csrf-token"
+CSRF_FORM_FIELD: Final = "csrf_token"
+UNSAFE_HTTP_METHODS: Final = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def csrf_enabled() -> bool:
+    return os.environ.get("CSRF_ENABLED", "1").lower() not in {"0", "false", "no"}
+
+
+def generate_csrf_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def get_request_csrf_token(request: Request) -> str:
+    token = getattr(request.state, "csrf_token", None)
+    if isinstance(token, str) and token:
+        return token
+    return request.cookies.get(CSRF_COOKIE_NAME) or generate_csrf_token()
+
+
+def set_csrf_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=token,
+        httponly=False,
+        secure=COOKIE_SECURE,
+        samesite="strict",
+    )
+
+
+def validate_csrf_token(request: Request, submitted_token: str | None) -> bool:
+    if not csrf_enabled():
+        return True
+    if not submitted_token:
+        return False
+    expected = get_request_csrf_token(request)
+    return secrets.compare_digest(expected, submitted_token)
+
+
+async def extract_submitted_csrf_token(request: Request) -> str | None:
+    header_token = request.headers.get(CSRF_HEADER_NAME)
+    if header_token:
+        return header_token
+
+    content_type = request.headers.get("content-type", "")
+    if (
+        "application/x-www-form-urlencoded" in content_type
+        or "multipart/form-data" in content_type
+    ):
+        form = await request.form()
+        value = form.get(CSRF_FORM_FIELD)
+        if isinstance(value, str):
+            return value
+    return None


### PR DESCRIPTION
## Summary
- Add double-submit CSRF protection (cookie + form field / `X-CSRF-Token` header for HTMX)
- Split account recovery into GET confirmation page + POST action so destructive recovery is not a bare GET
- Keep auth cookies at `SameSite=strict` after email promotion (remove the `lax` override)
- Disable CSRF in the test suite via `CSRF_ENABLED=0`; add dedicated CSRF tests with protection enabled

Closes #219

## Test plan
- [x] `uv run pytest tests/`
- [x] `uv run ty check .`