### PR TITLE
style(footer): improve site footer layout and typography

### DIFF
--- a/static/css/extras.css
+++ b/static/css/extras.css
@@ -434,6 +434,68 @@ input:invalid:not(:placeholder-shown) + .invalid-feedback {
     }
 }
 
+/* Site footer: align horizontal padding with navbar; spread copyright and contact. */
+.site-footer-inner {
+    padding-inline: 1.25rem;
+}
+
+.site-footer-row {
+    display: grid;
+    gap: 1.25rem;
+    text-align: center;
+}
+
+.site-footer-copyright,
+.site-footer-links,
+.site-footer-contact {
+    min-width: 0;
+}
+
+.site-footer-heading {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 1rem;
+    line-height: 1.15;
+    letter-spacing: -0.015em;
+    color: var(--muted);
+    margin: 0 0 0.5rem;
+}
+
+.site-footer-body,
+.site-footer-body a {
+    font-family: var(--font-body);
+    font-size: 1rem;
+    line-height: 1.55;
+    color: var(--muted);
+}
+
+.site-footer-body a:hover {
+    color: var(--primary);
+}
+
+@media (min-width: 992px) {
+    .site-footer-row {
+        grid-template-columns: 1fr auto 1fr;
+        align-items: end;
+        gap: 2rem;
+    }
+
+    .site-footer-copyright {
+        justify-self: start;
+        text-align: start;
+    }
+
+    .site-footer-links {
+        justify-self: center;
+        text-align: center;
+    }
+
+    .site-footer-contact {
+        justify-self: end;
+        text-align: end;
+    }
+}
+
 /* Pending invitations in organization members card. */
 .invitation-list-item-body {
     display: flex;

--- a/templates/base/partials/footer.html
+++ b/templates/base/partials/footer.html
@@ -1,28 +1,35 @@
-<footer class="bg-light py-4 mt-auto">
-  <div class="container">
-      <div class="row">
-          <!-- Copyright Information -->
-          <div class="col-md-4 text-center text-md-start mb-3 mb-md-0 d-flex flex-column justify-content-end">
-            <p class="mb-0">Created by Promptly Technologies, LLC and released under the <a href="https://opensource.org/license/mit">MIT License</a>.</p>
-          </div>
-
-          <!-- Quick Links -->
-          <div class="col-md-4 text-center mb-3 mb-md-0">
-              <h5 class="text-muted mb-2">Quick Links</h5>
-              <ul class="list-inline mb-0">
-                  <li class="list-inline-item"><a href="{{ url_for('read_static_page', page_name='about') }}" class="text-muted">About</a></li>
-                  <li class="list-inline-item"><a href="{{ url_for('read_static_page', page_name='privacy-policy') }}" class="text-muted">Privacy Policy</a></li>
-                  <li class="list-inline-item"><a href="{{ url_for('read_static_page', page_name='terms-of-service') }}" class="text-muted">Terms of Service</a></li>
-              </ul>
-          </div>
-
-          <!-- Contact Information -->
-          <div class="col-md-4 text-center text-md-end">
-              <h5 class="text-muted mb-2">Contact Us</h5>
-              <p class="mb-0">
-                  <a href="mailto:support@promptlytechnologies.com" class="text-muted">support@promptlytechnologies.com</a>
-              </p>
-          </div>
+<footer class="site-footer bg-light py-4 mt-auto">
+  <div class="container-fluid site-footer-inner">
+    <div class="site-footer-row">
+      <div class="site-footer-copyright">
+        <p class="site-footer-body mb-0">
+          Created by <a href="https://promptlytechnologies.com/">Promptly Technologies, LLC</a><br>
+          and released under the
+          <a href="https://opensource.org/license/mit">MIT License</a>.
+        </p>
       </div>
+
+      <div class="site-footer-links">
+        <h5 class="site-footer-heading mb-2">Quick Links</h5>
+        <ul class="list-inline site-footer-body mb-0">
+          <li class="list-inline-item">
+            <a href="{{ url_for('read_static_page', page_name='about') }}">About</a>
+          </li>
+          <li class="list-inline-item">
+            <a href="{{ url_for('read_static_page', page_name='privacy-policy') }}">Privacy Policy</a>
+          </li>
+          <li class="list-inline-item">
+            <a href="{{ url_for('read_static_page', page_name='terms-of-service') }}">Terms of Service</a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="site-footer-contact">
+        <h5 class="site-footer-heading mb-2">Contact Us</h5>
+        <p class="site-footer-body mb-0">
+          <a href="mailto:support@promptlytechnologies.com">support@promptlytechnologies.com</a>
+        </p>
+      </div>
+    </div>
   </div>
 </footer>

--- a/tests/browser/test_mobile_layout_overflow.py
+++ b/tests/browser/test_mobile_layout_overflow.py
@@ -501,13 +501,12 @@ def test_footer_columns_centered_on_mobile(
     html = _inject_static_css(auth_client_owner.get("/dashboard/").text)
 
     layout_check = """() => {
-        const cols = document.querySelectorAll('footer .row > [class*="col-md-4"]');
-        if (cols.length < 3) {
-            return { ok: false, reason: 'missing footer columns' };
+        const copyrightCol = document.querySelector('.site-footer-copyright');
+        const quickLinksCol = document.querySelector('.site-footer-links');
+        const contactCol = document.querySelector('.site-footer-contact');
+        if (!copyrightCol || !quickLinksCol || !contactCol) {
+            return { ok: false, reason: 'missing footer sections' };
         }
-        const copyrightCol = cols[0];
-        const quickLinksCol = cols[1];
-        const contactCol = cols[2];
         const ratio = document.documentElement.scrollWidth / window.innerWidth;
         const copyrightCentered = getComputedStyle(copyrightCol).textAlign === 'center';
         const quickLinksCentered = getComputedStyle(quickLinksCol).textAlign === 'center';
@@ -534,9 +533,9 @@ def test_footer_copyright_column_left_aligned_on_desktop(
     html = _inject_static_css(auth_client_owner.get("/dashboard/").text)
 
     layout_check = """() => {
-        const copyrightCol = document.querySelector('footer .row > [class*="col-md-4"]');
+        const copyrightCol = document.querySelector('.site-footer-copyright');
         if (!copyrightCol) {
-            return { ok: false, reason: 'missing copyright column' };
+            return { ok: false, reason: 'missing copyright section' };
         }
         return {
             ok: getComputedStyle(copyrightCol).textAlign === 'start'


### PR DESCRIPTION
## Summary
- Split the footer redesign out of #224 into its own PR to `main`
- Responsive grid layout with navbar-aligned padding
- Updated typography and link hover styling for copyright, quick links, and contact sections
- Browser tests updated for mobile centering and desktop left-alignment of the copyright column

## Test plan
- [ ] `uv run pytest tests/browser/test_mobile_layout_overflow.py -k footer -q`
- [ ] Visual check of footer on mobile and desktop viewports