### PR TITLE
Resolve merge conflicts for Propagate main to stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ BASE_URL=http://localhost:8000
 # Database connection mode (0 = direct, 1 = pooled)
 USE_POOL=0
 
+# SQLAlchemy pool (per process; keep small when using PgBouncer)
+# DB_POOL_SIZE=5
+# DB_MAX_OVERFLOW=5
+
 # Shared database settings
 DB_HOST=127.0.0.1
 DB_SSLMODE=prefer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- version list -->
 
+## v1.1.8 (2026-07-14)
+
+### Bug Fixes
+
+- **ci**: Keep Test workflow push triggers unfiltered
+  ([#229](https://github.com/Promptly-Technologies-LLC/fastapi-jinja2-postgres-webapp/pull/229),
+  [`2a88198`](https://github.com/Promptly-Technologies-LLC/fastapi-jinja2-postgres-webapp/commit/2a88198586079c45761afc69995a84586c76899d))
+
+### Code Style
+
+- **footer**: Improve site footer layout and typography
+  ([#226](https://github.com/Promptly-Technologies-LLC/fastapi-jinja2-postgres-webapp/pull/226),
+  [`85b5fe9`](https://github.com/Promptly-Technologies-LLC/fastapi-jinja2-postgres-webapp/commit/85b5fe92b266ae7459631c336275c82eeba3a610))
+
+### Documentation
+
+- Document stripe branch and add propagate/CI support
+  ([#229](https://github.com/Promptly-Technologies-LLC/fastapi-jinja2-postgres-webapp/pull/229),
+  [`2a88198`](https://github.com/Promptly-Technologies-LLC/fastapi-jinja2-postgres-webapp/commit/2a88198586079c45761afc69995a84586c76899d))
+
+
 ## v1.1.7 (2026-07-06)
 
 ### Bug Fixes

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ from exceptions.http_exceptions import (
     RateLimitError,
 )
 from exceptions.exceptions import NeedsNewTokens
-from utils.core.db import set_up_db
+from utils.core.db import set_up_db, clear_engine_cache
 
 logger = logging.getLogger("uvicorn.error")
 logger.setLevel(logging.DEBUG)
@@ -58,7 +58,7 @@ async def lifespan(app: FastAPI):
     load_dotenv()
     set_up_db()
     yield
-    # Optional shutdown logic
+    clear_engine_cache()
 
 
 # Initialize the FastAPI app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-jinja2-postgres-webapp"
-version = "1.1.7"
+version = "1.1.8"
 description = "A template webapp with a pure-Python FastAPI backend, frontend templating with Jinja2, and a Postgres database to power user auth"
 readme = "README.md"
 package-mode = false

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from playwright.sync_api import Browser, Page
 from tests.browser.db_helpers import browser_db_env
 from utils.core.db import (
+    clear_engine_cache,
     ensure_database_exists,
     get_connection_url,
     set_up_db,
@@ -149,6 +150,7 @@ def live_server(browser_env):
         proc.wait(timeout=5)
         with _temporary_env(browser_env):
             tear_down_db()
+        clear_engine_cache()
 
 
 @pytest.fixture(scope="session")
@@ -162,3 +164,4 @@ def live_server_csrf(browser_csrf_env):
         proc.wait(timeout=5)
         with _temporary_env(browser_csrf_env):
             tear_down_db()
+        clear_engine_cache()

--- a/tests/browser/db_helpers.py
+++ b/tests/browser/db_helpers.py
@@ -8,10 +8,10 @@ from contextlib import contextmanager
 from datetime import timedelta
 
 from dotenv import load_dotenv
-from sqlmodel import Session, create_engine, select
+from sqlmodel import Session, select
 
 from utils.core.auth import get_password_hash
-from utils.core.db import create_default_roles, get_connection_url
+from utils.core.db import create_default_roles, get_engine
 from utils.core.models import (
     Account,
     Invitation,
@@ -39,8 +39,7 @@ def browser_db_session():
     saved = {key: os.environ.get(key) for key in env}
     os.environ.update(env)
     try:
-        engine = create_engine(get_connection_url())
-        with Session(engine) as session:
+        with Session(get_engine()) as session:
             yield session
     finally:
         for key, value in saved.items():
@@ -168,8 +167,7 @@ def browser_csrf_db_session():
     saved = {key: os.environ.get(key) for key in env}
     os.environ.update(env)
     try:
-        engine = create_engine(get_connection_url())
-        with Session(engine) as session:
+        with Session(get_engine()) as session:
             yield session
     finally:
         for key, value in saved.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,13 @@ import os
 from typing import Generator, cast
 
 pytest_plugins = ["tests.frontend.fixtures"]
-from sqlmodel import create_engine, Session, select
+from sqlmodel import Session, select
 from fastapi.testclient import TestClient
 from dotenv import load_dotenv
 from utils.core.db import (
+    clear_engine_cache,
     get_connection_url,
+    get_engine,
     tear_down_db,
     set_up_db,
     create_default_roles,
@@ -74,15 +76,19 @@ def engine(env_vars):
     Create a new SQLModel engine for the test database.
     Use PostgreSQL for testing to match production environment.
     """
-    # Use PostgreSQL for testing to match production environment
+    # Use PostgreSQL for testing to match production environment. get_engine()
+    # returns the same cached pool the app itself uses via get_session(), so
+    # TestClient requests and direct test queries share one pool instead of
+    # opening a second one for the same database.
     ensure_database_exists(get_connection_url())
-    engine = create_engine(get_connection_url())
+    engine = get_engine()
     set_up_db(drop=True)
 
     yield engine
 
     # Clean up after tests
     tear_down_db()
+    clear_engine_cache()
 
 
 @pytest.fixture

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -3,6 +3,8 @@ from sqlmodel import Session, select, inspect
 from sqlalchemy import Engine
 from utils.core.db import (
     get_connection_url,
+    get_engine,
+    clear_engine_cache,
     assign_permissions_to_role,
     create_default_roles,
     create_permissions,
@@ -144,6 +146,84 @@ def test_get_connection_url_missing_pool_vars(monkeypatch):
 
     with pytest.raises(ValueError, match="Missing environment variables.*DB_POOL_PORT"):
         get_connection_url()
+
+
+# --- Engine cache ---
+
+
+@pytest.fixture
+def engine_cache():
+    """Ensure engine-cache tests start clean and never leak cached engines,
+    even when an assertion fails mid-test."""
+    clear_engine_cache()
+    yield
+    clear_engine_cache()
+
+
+def _direct_db_env(monkeypatch, *, name: str = "testdb", password: str = "testpass"):
+    for var in (
+        "USE_POOL",
+        "DB_HOST",
+        "DB_PORT",
+        "DB_NAME",
+        "DB_USER",
+        "DB_PASSWORD",
+        "DB_POOL_PORT",
+        "DB_POOL_NAME",
+        "DB_APPUSER",
+        "DB_APPUSER_PASSWORD",
+        "DB_POOL_SIZE",
+        "DB_MAX_OVERFLOW",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("DB_HOST", "localhost")
+    monkeypatch.setenv("DB_PORT", "5432")
+    monkeypatch.setenv("DB_NAME", name)
+    monkeypatch.setenv("DB_USER", "testuser")
+    monkeypatch.setenv("DB_PASSWORD", password)
+
+
+def test_get_engine_reuses_same_instance(engine_cache, monkeypatch):
+    _direct_db_env(monkeypatch)
+    assert get_engine() is get_engine()
+
+
+def test_get_engine_different_urls_get_different_engines(engine_cache, monkeypatch):
+    _direct_db_env(monkeypatch, name="db_a")
+    engine_a = get_engine()
+    _direct_db_env(monkeypatch, name="db_b")
+    engine_b = get_engine()
+    assert engine_a is not engine_b
+
+
+def test_get_engine_not_keyed_by_masked_str_password(engine_cache, monkeypatch):
+    """str(URL) masks passwords; cache must still separate credentials."""
+    _direct_db_env(monkeypatch, password="secretA")
+    engine_a = get_engine()
+    assert "***" in str(get_connection_url())
+    _direct_db_env(monkeypatch, password="secretB")
+    engine_b = get_engine()
+    assert engine_a is not engine_b
+
+
+def test_clear_engine_cache_disposes_and_creates_new(engine_cache, monkeypatch):
+    _direct_db_env(monkeypatch)
+    first = get_engine()
+    clear_engine_cache()
+    second = get_engine()
+    assert first is not second
+
+
+def test_get_engine_applies_pool_settings(engine_cache, monkeypatch):
+    _direct_db_env(monkeypatch)
+    monkeypatch.setenv("DB_POOL_SIZE", "3")
+    monkeypatch.setenv("DB_MAX_OVERFLOW", "2")
+    engine = get_engine()
+    assert engine.pool.size() == 3
+    # No public accessors for these; private attrs are stable in practice but
+    # may need updating on a SQLAlchemy major upgrade.
+    assert engine.pool._max_overflow == 2
+    assert engine.pool._pre_ping is True
 
 
 # --- Permission and Role Tests ---

--- a/utils/core/auth.py
+++ b/utils/core/auth.py
@@ -13,7 +13,7 @@ from jinja2.environment import Template
 from fastapi.templating import Jinja2Templates
 from fastapi import Cookie
 from starlette.responses import Response
-from utils.core.db import create_engine, get_connection_url
+from utils.core.db import get_engine
 from utils.core.models import (
     AccountRecoveryToken,
     EmailVerificationToken,
@@ -339,8 +339,7 @@ def send_reset_email_task(email: str) -> None:
     FastAPI background tasks should not reuse request-scoped resources from
     `yield` dependencies, because cleanup may run before the task executes.
     """
-    engine = create_engine(get_connection_url())
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         send_reset_email(email, session)
 
 

--- a/utils/core/db.py
+++ b/utils/core/db.py
@@ -1,8 +1,9 @@
 import os
 import logging
+import threading
 from itertools import chain
 from typing import Union, Sequence
-from sqlalchemy.engine import URL
+from sqlalchemy.engine import Engine, URL
 from sqlmodel import create_engine, Session, SQLModel, select, text
 from utils.core.models import (
     Account,
@@ -28,17 +29,60 @@ default_roles = ["Owner", "Administrator", "Member"]
 # --- Database connection functions ---
 
 
+# Cache by URL object (not str(url)): str(URL) masks passwords as "***", so
+# different credentials would collide on one cache key. Guarded by a lock:
+# sync dependencies run in FastAPI's threadpool, so concurrent first requests
+# would otherwise race and orphan an undisposed engine.
+_engines: dict[URL, Engine] = {}
+_engines_lock = threading.Lock()
+
+
+def get_engine() -> Engine:
+    """Return a process-wide cached engine for the current connection URL.
+
+    Calling create_engine() per request leaks pooled connections until GC
+    reclaims them. Cache one engine per URL so tests that swap DB_NAME still
+    get a separate pool per database. Pool settings (DB_POOL_SIZE,
+    DB_MAX_OVERFLOW) are read only when the engine for a URL is first
+    created; later environment changes have no effect on a cached engine.
+    """
+    url = get_connection_url()
+    with _engines_lock:
+        engine = _engines.get(url)
+        if engine is None:
+            engine = create_engine(
+                url,
+                pool_pre_ping=True,
+                pool_size=int(os.getenv("DB_POOL_SIZE", "5")),
+                max_overflow=int(os.getenv("DB_MAX_OVERFLOW", "5")),
+            )
+            _engines[url] = engine
+    return engine
+
+
+def clear_engine_cache() -> None:
+    """Dispose and drop all cached engines (shutdown / tests)."""
+    with _engines_lock:
+        engines = list(_engines.values())
+        _engines.clear()
+    for engine in engines:
+        engine.dispose()
+
+
 def ensure_database_exists(url: URL) -> None:
     dbname = url.database
     server_url = url.set(database="postgres")
     engine = create_engine(server_url, isolation_level="AUTOCOMMIT")
-    with engine.connect() as conn:
-        exists = conn.execute(
-            text("SELECT 1 FROM pg_database WHERE datname = :n"),
-            {"n": dbname},
-        ).scalar()
-        if not exists:
-            conn.execute(text(f'CREATE DATABASE "{dbname}"'))
+    try:
+        with engine.connect() as conn:
+            exists = conn.execute(
+                text("SELECT 1 FROM pg_database WHERE datname = :n"),
+                {"n": dbname},
+            ).scalar()
+            if not exists:
+                conn.execute(text(f'CREATE DATABASE "{dbname}"'))
+    finally:
+        engine.dispose()
 
 
 def get_connection_url() -> URL:
@@ -259,19 +303,21 @@ def set_up_db(drop: bool = False) -> None:
         drop (bool): If True, drops all existing tables before creating new ones.
     """
     engine = create_engine(get_connection_url())
-    if drop:
-        SQLModel.metadata.drop_all(engine)
-    # Ensure the private schema exists before creating tables
-    with engine.connect() as conn:
-        conn.execute(text("CREATE SCHEMA IF NOT EXISTS private"))
-        conn.commit()
-    SQLModel.metadata.create_all(engine)
-    # Create default permissions and seed account emails
-    with Session(engine) as session:
-        create_permissions(session)
-        session.commit()
-        seed_account_emails(session)
-    engine.dispose()
+    try:
+        if drop:
+            SQLModel.metadata.drop_all(engine)
+        # Ensure the private schema exists before creating tables
+        with engine.connect() as conn:
+            conn.execute(text("CREATE SCHEMA IF NOT EXISTS private"))
+            conn.commit()
+        SQLModel.metadata.create_all(engine)
+        # Create default permissions and seed account emails
+        with Session(engine) as session:
+            create_permissions(session)
+            session.commit()
+            seed_account_emails(session)
+    finally:
+        engine.dispose()
 
 
 def tear_down_db() -> None:
@@ -279,8 +325,10 @@ def tear_down_db() -> None:
     Tears down the database by dropping all tables and the private schema.
     """
     engine = create_engine(get_connection_url())
-    SQLModel.metadata.drop_all(engine)
-    with engine.connect() as conn:
-        conn.execute(text("DROP SCHEMA IF EXISTS private CASCADE"))
-        conn.commit()
-    engine.dispose()
+    try:
+        SQLModel.metadata.drop_all(engine)
+        with engine.connect() as conn:
+            conn.execute(text("DROP SCHEMA IF EXISTS private CASCADE"))
+            conn.commit()
+    finally:
+        engine.dispose()

--- a/utils/core/dependencies.py
+++ b/utils/core/dependencies.py
@@ -13,7 +13,7 @@ from utils.core.auth import (
     oauth2_scheme_cookie,
     verify_password,
 )
-from utils.core.db import create_engine, get_connection_url
+from utils.core.db import get_engine
 from utils.core.models import (
     User,
     Role,
@@ -43,8 +43,7 @@ def get_session() -> Generator[Session, None, None]:
     Yields:
         Session: A SQLModel session object for database operations.
     """
-    engine = create_engine(get_connection_url())
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         yield session
 
 
@@ -434,8 +433,7 @@ async def get_user_from_request(request: Request) -> Optional[User]:
     tokens = (access_token, refresh_token)
 
     # Get a database session
-    engine = create_engine(get_connection_url())
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         user, new_access_token, new_refresh_token = get_user_from_tokens(
             tokens, session
         )

--- a/utils/core/rate_limit.py
+++ b/utils/core/rate_limit.py
@@ -10,22 +10,13 @@ from typing import Protocol, Tuple, runtime_checkable
 from fastapi import Request, Form
 from pydantic import EmailStr
 from dotenv import load_dotenv
-from sqlmodel import Session, col, create_engine, delete, select
+from sqlmodel import Session, col, delete, select
 
-from utils.core.db import get_connection_url
+from utils.core.db import get_engine
 from utils.core.models import RateLimitAttempt
 
 logger = getLogger("uvicorn.error")
 load_dotenv()
-
-_rate_limit_engine = None
-
-
-def _get_rate_limit_engine():
-    global _rate_limit_engine
-    if _rate_limit_engine is None:
-        _rate_limit_engine = create_engine(get_connection_url())
-    return _rate_limit_engine
 
 
 @runtime_checkable
@@ -235,7 +226,7 @@ class PostgresRateLimitWindow:
 
     def check(self, key: str) -> Tuple[bool, int]:
         now = datetime.now(UTC)
-        with Session(_get_rate_limit_engine()) as session:
+        with Session(get_engine()) as session:
             attempts = self._recent_attempts(session, key, now)
             if len(attempts) >= self.max_attempts:
                 oldest = attempts[0].attempted_at
@@ -250,7 +241,7 @@ class PostgresRateLimitWindow:
             return False, 0
 
     def record(self, key: str) -> None:
-        with Session(_get_rate_limit_engine()) as session:
+        with Session(get_engine()) as session:
             session.add(
                 RateLimitAttempt(
                     scope=self.scope, key=key, attempted_at=datetime.now(UTC)
@@ -260,12 +251,12 @@ class PostgresRateLimitWindow:
 
     def remaining(self, key: str) -> int:
         now = datetime.now(UTC)
-        with Session(_get_rate_limit_engine()) as session:
+        with Session(get_engine()) as session:
             attempts = self._recent_attempts(session, key, now)
             return max(0, self.max_attempts - len(attempts))
 
     def reset(self, key: str) -> None:
-        with Session(_get_rate_limit_engine()) as session:
+        with Session(get_engine()) as session:
             session.exec(
                 delete(RateLimitAttempt).where(
                     col(RateLimitAttempt.scope) == self.scope,
@@ -276,7 +267,7 @@ class PostgresRateLimitWindow:
 
     def prune(self) -> None:
         cutoff = self._cutoff(datetime.now(UTC))
-        with Session(_get_rate_limit_engine()) as session:
+        with Session(get_engine()) as session:
             session.exec(
                 delete(RateLimitAttempt).where(
                     col(RateLimitAttempt.scope) == self.scope,
@@ -286,7 +277,7 @@ class PostgresRateLimitWindow:
             session.commit()
 
     def clear(self) -> None:
-        with Session(_get_rate_limit_engine()) as session:
+        with Session(get_engine()) as session:
             session.exec(
                 delete(RateLimitAttempt).where(
                     col(RateLimitAttempt.scope) == self.scope

--- a/uv.lock
+++ b/uv.lock
@@ -493,7 +493,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-jinja2-postgres-webapp"
-version = "1.1.7"
+version = "1.1.8"
 source = { virtual = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Resolves merge conflicts from [#234](https://github.com/Promptly-Technologies-LLC/fastapi-jinja2-postgres-webapp/pull/234) (`Propagate main to stripe`) so main's engine-cache fix can land on `stripe`
- In `main.py`, keep Stripe billing imports/`validate_billing_environment` and add `clear_engine_cache()` on app shutdown
- In `utils/core/db.py`, keep main's shared/locked engine cache (drop the stripe-era singleton), and combine `set_up_db` so it still runs `sync_default_role_permissions` inside try/finally dispose

## Conflict files
- `main.py`
- `utils/core/db.py`

## Test plan
- [x] `uv run ty check .` — all checks passed
- [x] `uv run pytest tests --ignore=tests/browser` — 524 passed
- [ ] Confirm this PR is mergeable into `stripe` and supersedes #234

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5998ab41-84d4-427c-9f66-77a39bc1c437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5998ab41-84d4-427c-9f66-77a39bc1c437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

